### PR TITLE
feat: 본인인증 ui 구현 및 임시 인증번호로 회원가입 구현

### DIFF
--- a/app/auth/phone/index.tsx
+++ b/app/auth/phone/index.tsx
@@ -6,10 +6,20 @@ import { useState } from 'react';
 import { TextField } from '@/components/common/Inputs/TextField';
 import { LongButton } from '@/components/common/buttons/LongButton';
 import { useMemo } from 'react';
+import DefaultModal from '@/components/common/modals/DefaultModal';
+import { useSignup } from '@/hooks/useSignUp';
+import { useSignupDraft } from '@/store/useSignupDraft';
 export default function Index() {
   const router = useRouter();
 
   const [phone, setPhone] = useState('');
+  const [authNumber, setAuthNumber] = useState('');
+  const [requestAuthNumber, setRequestAuthNumber] = useState(false);
+  const [visibleModal, setVisibleModal] = useState(false);
+  const [disabledButton, setDisabledButton] = useState(false);
+
+  const { email, password, confirmPassword, clear } = useSignupDraft();
+  const MOCK_AUTH_NUMBER = '123456';
 
   const formatPhoneNumber = (phone: string) => {
     const digits = phone.replace(/\D/g, '');
@@ -19,11 +29,38 @@ export default function Index() {
     return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
   };
 
+  const checkAuthNumber = (authNumber: string) => {
+    return authNumber === MOCK_AUTH_NUMBER;
+  };
+  const signupMutation = useSignup({
+    onSuccess: () => {
+      clear();
+      router.replace('/auth/signUp/result');
+    },
+  });
+
   const canSubmit = useMemo(() => {
-    if (phone.length !== 11) return false;
-    if (phone.slice(0, 3) !== '010') return false;
+    if (phone.length !== 11 || phone.slice(0, 3) !== '010') {
+      setDisabledButton(true);
+      return false;
+    }
+    if (requestAuthNumber) {
+      if (authNumber.length !== 6) {
+        setDisabledButton(true);
+        return false;
+      }
+    }
+    setDisabledButton(false);
     return true;
-  }, [phone]);
+  }, [phone, authNumber, requestAuthNumber]);
+
+  const onVerified = () => {
+    signupMutation.mutate({
+      email,
+      password,
+      password2: confirmPassword,
+    });
+  };
 
   return (
     <SafeAreaView className='flex-1 bg-white'>
@@ -52,17 +89,48 @@ export default function Index() {
           }
           placeholder='휴대폰 번호를 입력해주세요.'
           keyboardType='number-pad'
+          disabled={requestAuthNumber}
         />
+        {requestAuthNumber && (
+          <TextField
+            menu={1}
+            value={authNumber}
+            onChangeText={(text) =>
+              setAuthNumber(text.replace(/\D/g, '').slice(0, 6))
+            }
+            placeholder='인증번호를 입력해주세요.'
+            keyboardType='number-pad'
+          />
+        )}
         <View className='mt-[30px]'>
           <LongButton
-            label='인증 번호 요청'
+            label={requestAuthNumber ? '본인 인증 완료' : '인증 번호 요청'}
             onPress={() => {
-              router.push('/auth/find/id/result');
+              // router.push('/auth/find/id/result');
+              if (requestAuthNumber) {
+                // 인증번호 확인
+                if (checkAuthNumber(authNumber)) {
+                  onVerified();
+                } else {
+                  setVisibleModal(true);
+                }
+              } else {
+                setRequestAuthNumber(true);
+              }
             }}
-            disabled={!canSubmit}
+            disabled={disabledButton || !canSubmit}
           />
         </View>
       </View>
+      <DefaultModal
+        visible={visibleModal}
+        onConfirm={() => setVisibleModal(false)}
+        onCancel={() => setVisibleModal(false)}
+        // title='인증번호가 일치하지 않습니다.'
+        message='인증번호가 일치하지 않습니다'
+        confirmText='확인'
+        singleButton
+      />
     </SafeAreaView>
   );
 }

--- a/app/auth/phone/index.tsx
+++ b/app/auth/phone/index.tsx
@@ -2,9 +2,28 @@ import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
 import Navigation from '@/components/layout/Navigation';
 import { Stack, useRouter } from 'expo-router';
 import { Pressable, SafeAreaView, Text, View } from 'react-native';
-
+import { useState } from 'react';
+import { TextField } from '@/components/common/Inputs/TextField';
+import { LongButton } from '@/components/common/buttons/LongButton';
+import { useMemo } from 'react';
 export default function Index() {
   const router = useRouter();
+
+  const [phone, setPhone] = useState('');
+
+  const formatPhoneNumber = (phone: string) => {
+    const digits = phone.replace(/\D/g, '');
+
+    if (digits.length <= 3) return digits; // 010
+    if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`; // 010-0000
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  };
+
+  const canSubmit = useMemo(() => {
+    if (phone.length !== 11) return false;
+    if (phone.slice(0, 3) !== '010') return false;
+    return true;
+  }, [phone]);
 
   return (
     <SafeAreaView className='flex-1 bg-white'>
@@ -16,70 +35,33 @@ export default function Index() {
 
       <View className='p-5'>
         <Text className='text-h-lg font-extrabold text-gray-700 mb-[12px]'>
-          이용중인 통신사
+          휴대폰 본인 인증
+        </Text>
+        <Text className='text-b-md font-bold text-gray-700 mb-[8px]'>
+          계정 생성 후,
+        </Text>
+        <Text className='text-b-md font-bold text-gray-700 mb-[25px]'>
+          휴대폰 본인인증을 완료하면 가입이 완료됩니다.
         </Text>
 
-        <Pressable
-          onPress={() => {
-            console.log('SKT');
-          }}
-        >
-          <Text>SKT</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            console.log('KT');
-          }}
-        >
-          <Text>KT</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            console.log('LG U+');
-          }}
-        >
-          <Text>LG U+</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            console.log('SKT 알뜰폰');
-          }}
-        >
-          <Text>SKT 알뜰폰</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            console.log('KT 알뜰폰');
-          }}
-        >
-          <Text>KT 알뜰폰</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            console.log('LG U+ 알뜰폰');
-          }}
-        >
-          <Text>LG U+ 알뜰폰</Text>
-        </Pressable>
-
-        <Pressable
-          onPress={() => {
-            router.push('/auth/find/id/result');
-          }}
-        >
-          <Text>계정 찾기 성공</Text>
-        </Pressable>
-
-        <Pressable
-          onPress={() => {
-            router.push({
-              pathname: '/auth/find/id',
-              params: { open: 'fail' },
-            });
-          }}
-        >
-          <Text>계정 찾기 실패</Text>
-        </Pressable>
+        <TextField
+          menu={1}
+          value={formatPhoneNumber(phone)}
+          onChangeText={(text) =>
+            setPhone(text.replace(/\D/g, '').slice(0, 11))
+          }
+          placeholder='휴대폰 번호를 입력해주세요.'
+          keyboardType='number-pad'
+        />
+        <View className='mt-[30px]'>
+          <LongButton
+            label='인증 번호 요청'
+            onPress={() => {
+              router.push('/auth/find/id/result');
+            }}
+            disabled={!canSubmit}
+          />
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/app/auth/signUp/index.tsx
+++ b/app/auth/signUp/index.tsx
@@ -88,11 +88,12 @@ export default function Index() {
 
   const onPressSubmit = async () => {
     if (!canSubmit) return;
-    signupMutation.mutate({
-      email,
-      password,
-      password2: confirmPassword,
-    });
+    router.replace('/auth/phone');
+    // signupMutation.mutate({
+    //   email,
+    //   password,
+    //   password2: confirmPassword,
+    // });
   };
 
   return (

--- a/app/auth/signUp/index.tsx
+++ b/app/auth/signUp/index.tsx
@@ -18,6 +18,7 @@ import { PortalProvider } from '@gorhom/portal';
 import { Stack, useRouter } from 'expo-router';
 import { useMemo, useRef, useState } from 'react';
 import { Pressable, SafeAreaView, Text, View } from 'react-native';
+import { useSignupDraft } from '@/store/useSignupDraft';
 import Svg, { Path } from 'react-native-svg';
 const TERMS: { id: string; terms: string; essential: boolean }[] = [
   { id: 'service', terms: '이용 약관 동의', essential: true },
@@ -26,13 +27,19 @@ const TERMS: { id: string; terms: string; essential: boolean }[] = [
   { id: 'appUsage', terms: '앱 이용 정보 수집 동의', essential: true },
   { id: 'notification', terms: '알림 및 푸시 알림 동의', essential: false },
 ];
+
 export default function Index() {
   const router = useRouter();
-
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
   const [checkedSet, setCheckedSet] = useState<Set<number>>(new Set());
+  const {
+    email,
+    password,
+    confirmPassword,
+    setEmail,
+    setPassword,
+    setConfirmPassword,
+  } = useSignupDraft();
+
   // ===== BottomSheet =====
   const sheetRef = useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => [462], []);
@@ -88,12 +95,7 @@ export default function Index() {
 
   const onPressSubmit = async () => {
     if (!canSubmit) return;
-    router.replace('/auth/phone');
-    // signupMutation.mutate({
-    //   email,
-    //   password,
-    //   password2: confirmPassword,
-    // });
+    router.push('/auth/phone');
   };
 
   return (

--- a/app/auth/signUp/result.tsx
+++ b/app/auth/signUp/result.tsx
@@ -1,0 +1,40 @@
+import { Stack } from 'expo-router';
+import { View, Text, SafeAreaView } from 'react-native';
+import Logo from '@/assets/icons/ic_logo_start.svg';
+import { LongButton } from '@/components/common/buttons/LongButton';
+import { useRouter } from 'expo-router';
+const Result = () => {
+  const router = useRouter();
+  return (
+    <SafeAreaView className='flex-1 bg-white'>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View className='items-center flex-1 mb-[58px]'>
+        <Text className='mt-[75px] text-h-lg font-extrabold text-gray-700'>
+          회원가입 완료
+        </Text>
+        <View className='items-center w-full justify-center boer flex-1'>
+          <Logo width={112} height={33} />
+          <View className='flex-col items-center mt-[18px] '>
+            <Text className='text-b-sm font-regular text-gray-900'>
+              다이어트 필수 정보,
+            </Text>
+            <Text className='text-b-sm font-regular text-gray-900'>
+              보조제 성분부터 후기까지 한번에
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View className='px-4 mb-[11px]'>
+        <LongButton
+          label='시작하기'
+          onPress={() => {
+            router.replace('/auth/login/email');
+          }}
+          height='h-[60px]'
+        />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default Result;

--- a/components/common/Inputs/TextField.tsx
+++ b/components/common/Inputs/TextField.tsx
@@ -2,7 +2,13 @@ import ChekckIcon from '@/assets/icons/auth/ic_green_check.svg';
 import XIcon from '@/assets/icons/auth/ic_red_x.svg';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useMemo, useState } from 'react';
-import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import {
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  KeyboardTypeOptions,
+} from 'react-native';
 
 type TextFieldProps = {
   placeholder?: string;
@@ -19,6 +25,7 @@ type TextFieldProps = {
   menu?: 1 | 2;
   validateFirst?: (text: string) => boolean;
   validateSecond?: (text: string) => boolean;
+  keyboardType?: KeyboardTypeOptions;
 };
 
 export const TextField: React.FC<TextFieldProps> = ({
@@ -35,6 +42,7 @@ export const TextField: React.FC<TextFieldProps> = ({
   menu,
   validateFirst,
   validateSecond,
+  keyboardType,
 }) => {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -264,6 +272,7 @@ export const TextField: React.FC<TextFieldProps> = ({
           placeholderTextColor='#9ca3af'
           returnKeyType='done'
           blurOnSubmit
+          keyboardType={keyboardType}
         />
 
         {secureTextEntry && !disabled && (

--- a/components/common/Inputs/TextField.tsx
+++ b/components/common/Inputs/TextField.tsx
@@ -258,10 +258,10 @@ export const TextField: React.FC<TextFieldProps> = ({
   return (
     <View>
       <View
-        className={`flex-row items-center w-full h-[60px] rounded-xl py-[21px] px-4 border ${borderColorClass}`}
+        className={`flex-row items-center w-full h-[60px] rounded-xl py-[21px] px-4 border ${borderColorClass} ${disabled ? 'bg-gray-50' : ''}`}
       >
         <TextInput
-          className='flex-1 text-b-sm font-bold text-gray-900'
+          className={`flex-1 text-b-sm font-bold text-gray-900 ${disabled ? 'text-gray-400' : ''}`}
           value={value}
           onChangeText={handleChangeText}
           onBlur={handleBlur}

--- a/hooks/useSignUp.tsx
+++ b/hooks/useSignUp.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query';
-import { Alert } from 'react-native';
 import { signUp, SignUpRequest, SignUpResponse } from '../services/auth/signUp';
 
 export const useSignup = (opts?: {
@@ -10,7 +9,6 @@ export const useSignup = (opts?: {
     mutationFn: signUp,
     onSuccess: (data) => {
       console.log('회원가입 성공:', data);
-      Alert.alert('회원가입 완료', '휴대폰 본인인증을 진행해주세요.');
       opts?.onSuccess?.(data);
     },
     onError: (err: any) => {
@@ -32,7 +30,6 @@ export const useSignup = (opts?: {
         msg = err.response.data;
       }
 
-      Alert.alert(msg);
       opts?.onError?.(err);
     },
   });

--- a/store/useSignupDraft.ts
+++ b/store/useSignupDraft.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+type Draft = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  setEmail: (v: string) => void;
+  setPassword: (v: string) => void;
+  setConfirmPassword: (v: string) => void;
+  clear: () => void;
+};
+
+export const useSignupDraft = create<Draft>((set) => ({
+  email: '',
+  password: '',
+  confirmPassword: '',
+  setEmail: (v) => set({ email: v }),
+  setPassword: (v) => set({ password: v }),
+  setConfirmPassword: (v) => set({ confirmPassword: v }),
+  clear: () => set({ email: '', password: '', confirmPassword: '' }),
+}));


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
- #30 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 본인인증 ui 구현하였습니다
- 임시 인증번호 123456으로 설정하여 회원가입 기능 연동해두었습니다.

## 🗣️ 팀원에게 공유할 내용
- TextField 컴포넌트 Props에 keyboardType 추가하였습니다.
    -  keyboardType='number-pad' 시 번호키패드로 구현됩니다.
- store/useSignupDraft 구현하여 Zustand 상태관리 라이브러리로 회원가입 과정에서 입력한 값들을 임시 저장해 두는 스토어를 만들었습니다
    - 로컬에서서 회원가입 시 잠깐 들고 있어야 하는 입력 데이터라 가볍고 전역상태 관리에 적합한 Zustand를 선택하였습니다.
    - email, password, confirmPassword 같은 입력값과 이를 업데이트하는 setEmail, setPassword, setConfirmPassword, 모두 비우는 clear 함수
    
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->