### PR TITLE
feat: 신고하기 및 본인인증 관련 api 연동

### DIFF
--- a/app/auth/find/id/index.tsx
+++ b/app/auth/find/id/index.tsx
@@ -38,7 +38,7 @@ export default function Index() {
         <LongButton
           label='휴대폰 본인인증'
           onPress={() => {
-            router.push('/auth/phone');
+            router.push('/auth/phone?menu=findId');
           }}
         />
       </View>

--- a/app/auth/find/id/result.tsx
+++ b/app/auth/find/id/result.tsx
@@ -3,8 +3,21 @@ import { LongButton } from '@/components/common/buttons/LongButton';
 import Navigation from '@/components/layout/Navigation';
 import { Stack, useRouter } from 'expo-router';
 import { SafeAreaView, Text, View } from 'react-native';
+import { useFoundAccounts } from '@/store/useFoundAccounts';
+
+const formatDate = (iso: string | null) => {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '-';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}.${m}.${day}`;
+};
+
 export default function Result() {
   const router = useRouter();
+  const { phone, accounts, clear } = useFoundAccounts();
 
   return (
     <SafeAreaView className='flex-1 bg-white'>
@@ -22,23 +35,33 @@ export default function Result() {
           가입하신 SNS 또는 이메일 계정을 찾았습니다.
         </Text>
 
-        <View className='w-full bg-gray-50 rounded-[12px] px-5 py-[25px] space-y-[25px]'>
-          <View className='flex-row justify-between'>
-            <Text className='text-c1 font-bold text-gray-500'>가입 계정</Text>
-            <Text className='text-c1 font-bold text-gray-700'>
-              dki688@naver.com
-            </Text>
+        {accounts.map((account, idx) => (
+          <View
+            key={idx}
+            className='w-full bg-gray-50 rounded-[12px] px-5 py-[25px] space-y-[25px]'
+          >
+            <View className='flex-row justify-between'>
+              <Text className='text-c1 font-bold text-gray-500'>가입 계정</Text>
+              <Text className='text-c1 font-bold text-gray-700'>
+                {account.email}
+              </Text>
+            </View>
+            <View className='flex-row justify-between'>
+              <Text className='text-c1 font-bold text-gray-500'>가입 경로</Text>
+              <Text className='text-c1 font-bold text-gray-700'>
+                {account.login_type}
+              </Text>
+            </View>
+            <View className='flex-row justify-between'>
+              <Text className='text-c1 font-bold text-gray-500'>가입일</Text>
+              <Text className='text-c1 font-bold text-gray-700'>
+                {formatDate(account.created_at)}
+              </Text>
+            </View>
           </View>
-          <View className='flex-row justify-between'>
-            <Text className='text-c1 font-bold text-gray-500'>가입 경로</Text>
-            <Text className='text-c1 font-bold text-gray-700'>이메일</Text>
-          </View>
-          <View className='flex-row justify-between'>
-            <Text className='text-c1 font-bold text-gray-500'>가입일</Text>
-            <Text className='text-c1 font-bold text-gray-700'>2021.05.12</Text>
-          </View>
-        </View>
+        ))}
       </View>
+
       <View className='p-5'>
         <LongButton label='가입한 계정으로 로그인' onPress={() => {}} />
       </View>

--- a/app/auth/find/id/result.tsx
+++ b/app/auth/find/id/result.tsx
@@ -1,7 +1,7 @@
 import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
 import { LongButton } from '@/components/common/buttons/LongButton';
 import Navigation from '@/components/layout/Navigation';
-import { Stack, useRouter } from 'expo-router';
+import { Stack, useNavigation, useRouter } from 'expo-router';
 import { SafeAreaView, Text, View } from 'react-native';
 import { useFoundAccounts } from '@/store/useFoundAccounts';
 
@@ -18,13 +18,13 @@ const formatDate = (iso: string | null) => {
 export default function Result() {
   const router = useRouter();
   const { phone, accounts, clear } = useFoundAccounts();
-
+  const navigation = useNavigation<any>();
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
       <Navigation
         left={<ArrowLeftIcon width={20} height={20} />}
-        onLeftPress={() => router.back()}
+        onLeftPress={() => navigation.pop(2)}
       />
 
       <View className='p-5 flex-1'>
@@ -63,7 +63,12 @@ export default function Result() {
       </View>
 
       <View className='p-5'>
-        <LongButton label='가입한 계정으로 로그인' onPress={() => {}} />
+        <LongButton
+          label='가입한 계정으로 로그인'
+          onPress={() => {
+            router.push('/auth/login/email');
+          }}
+        />
       </View>
     </SafeAreaView>
   );

--- a/app/auth/find/password/change.tsx
+++ b/app/auth/find/password/change.tsx
@@ -1,0 +1,116 @@
+import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
+import { LongButton } from '@/components/common/buttons/LongButton';
+import { TextField } from '@/components/common/Inputs/TextField';
+import Navigation from '@/components/layout/Navigation';
+import {
+  hasPasswordComposition,
+  isEmail,
+  isLen8to20,
+  isSamePassword,
+} from '@/utils/validation';
+import { Stack, useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Pressable, SafeAreaView, Text, View } from 'react-native';
+import { useSignupDraft } from '@/store/useSignupDraft';
+import { usePasswordReset } from '@/store/usePasswordReset';
+import { useResetPassword } from '@/hooks/auth/useFindAccount';
+export default function change() {
+  const router = useRouter();
+  const { email, verificationToken, clear } = usePasswordReset();
+  const [isEmailValid, setIsEmailValid] = useState(false);
+  const [newPwd, setNewPwd] = useState('');
+  const [confirmPwd, setConfirmPwd] = useState('');
+  const [validNew, setValidNew] = useState(false);
+  const [matchConfirm, setMatchConfirm] = useState(false);
+
+  // 이메일 형식 체크
+  const validateEmail = (value: string) => {
+    const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return regex.test(value);
+  };
+
+  const resetPasswordMutation = useResetPassword({
+    onSuccess: () => {
+      clear();
+      router.replace('/mypage/completion?action=password');
+    },
+  });
+
+  useEffect(() => {
+    if (!validateEmail(email)) {
+      setIsEmailValid(true);
+    } else {
+      setIsEmailValid(false);
+    }
+  }, [email]);
+
+  const handleSubmit = () => {
+    resetPasswordMutation.mutate({
+      email,
+      new_password1: newPwd,
+      new_password2: confirmPwd,
+      verification_token: verificationToken!,
+    });
+  };
+
+  return (
+    <SafeAreaView className='flex-1 bg-white'>
+      <Stack.Screen options={{ headerShown: false }} />
+      <Navigation
+        left={<ArrowLeftIcon width={20} height={20} />}
+        onLeftPress={() => router.back()}
+      />
+
+      <View className='p-5'>
+        <Text className='text-h-lg font-extrabold text-gray-700 mb-[12px]'>
+          비밀번호 변경
+        </Text>
+        <Text className='text-b-md font-bold text-gray-700 mb-[8px]'>
+          새로운 비밀번호를 입력해주세요.
+        </Text>
+
+        <View className='mt-[25px] mb-[25px]'>
+          <View className='mb-[18px]'>
+            <TextField
+              menu={1}
+              value={newPwd}
+              onChangeText={setNewPwd}
+              placeholder='비밀번호를 입력해주세요.'
+              firstMessage='8-20자 이내'
+              secondMessage='영문, 숫자, 특수문자 포함'
+              validateFirst={isLen8to20}
+              validateSecond={hasPasswordComposition}
+            />
+          </View>
+          <View>
+            <TextField
+              menu={1}
+              value={confirmPwd}
+              onChangeText={setConfirmPwd}
+              placeholder='비밀번호를 입력해주세요.'
+              firstMessage='비밀번호 일치'
+              validateFirst={() => isSamePassword(newPwd, confirmPwd)}
+            />
+          </View>
+        </View>
+        <View className='mb-[25px]'>
+          <LongButton
+            label={
+              resetPasswordMutation.isPending ? '변경 중...' : '비밀번호 변경'
+            }
+            onPress={handleSubmit}
+            disabled={
+              newPwd.length === 0 ||
+              confirmPwd.length === 0 ||
+              !isSamePassword(newPwd, confirmPwd) ||
+              !isLen8to20(newPwd) ||
+              !isLen8to20(confirmPwd) ||
+              !hasPasswordComposition(newPwd) ||
+              !hasPasswordComposition(confirmPwd)
+            }
+          />
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/app/auth/find/password/change.tsx
+++ b/app/auth/find/password/change.tsx
@@ -4,30 +4,21 @@ import { TextField } from '@/components/common/Inputs/TextField';
 import Navigation from '@/components/layout/Navigation';
 import {
   hasPasswordComposition,
-  isEmail,
   isLen8to20,
   isSamePassword,
 } from '@/utils/validation';
 import { Stack, useRouter } from 'expo-router';
-import { useEffect, useState } from 'react';
-import { Pressable, SafeAreaView, Text, View } from 'react-native';
-import { useSignupDraft } from '@/store/useSignupDraft';
+import { useState } from 'react';
+import { SafeAreaView, Text, View } from 'react-native';
 import { usePasswordReset } from '@/store/usePasswordReset';
 import { useResetPassword } from '@/hooks/auth/useFindAccount';
+
 export default function change() {
   const router = useRouter();
   const { email, verificationToken, clear } = usePasswordReset();
-  const [isEmailValid, setIsEmailValid] = useState(false);
+
   const [newPwd, setNewPwd] = useState('');
   const [confirmPwd, setConfirmPwd] = useState('');
-  const [validNew, setValidNew] = useState(false);
-  const [matchConfirm, setMatchConfirm] = useState(false);
-
-  // 이메일 형식 체크
-  const validateEmail = (value: string) => {
-    const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return regex.test(value);
-  };
 
   const resetPasswordMutation = useResetPassword({
     onSuccess: () => {
@@ -35,14 +26,6 @@ export default function change() {
       router.replace('/mypage/completion?action=password');
     },
   });
-
-  useEffect(() => {
-    if (!validateEmail(email)) {
-      setIsEmailValid(true);
-    } else {
-      setIsEmailValid(false);
-    }
-  }, [email]);
 
   const handleSubmit = () => {
     resetPasswordMutation.mutate({
@@ -52,6 +35,11 @@ export default function change() {
       verification_token: verificationToken!,
     });
   };
+
+  const canSubmit =
+    isLen8to20(newPwd) &&
+    hasPasswordComposition(newPwd) &&
+    isSamePassword(newPwd, confirmPwd);
 
   return (
     <SafeAreaView className='flex-1 bg-white'>
@@ -99,15 +87,7 @@ export default function change() {
               resetPasswordMutation.isPending ? '변경 중...' : '비밀번호 변경'
             }
             onPress={handleSubmit}
-            disabled={
-              newPwd.length === 0 ||
-              confirmPwd.length === 0 ||
-              !isSamePassword(newPwd, confirmPwd) ||
-              !isLen8to20(newPwd) ||
-              !isLen8to20(confirmPwd) ||
-              !hasPasswordComposition(newPwd) ||
-              !hasPasswordComposition(confirmPwd)
-            }
+            disabled={!canSubmit || resetPasswordMutation.isPending}
           />
         </View>
       </View>

--- a/app/auth/find/password/index.tsx
+++ b/app/auth/find/password/index.tsx
@@ -6,12 +6,13 @@ import { isEmail } from '@/utils/validation';
 import { Stack, useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Pressable, SafeAreaView, Text, View } from 'react-native';
-import { useSignupDraft } from '@/store/useSignupDraft';
+import { usePasswordReset } from '@/store/usePasswordReset';
+
 export default function Index() {
   const router = useRouter();
 
   const [isEmailValid, setIsEmailValid] = useState(false);
-  const { email, setEmail } = useSignupDraft();
+  const { email, setEmail } = usePasswordReset();
   // 이메일 형식 체크
   const validateEmail = (value: string) => {
     const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -59,7 +60,7 @@ export default function Index() {
           <LongButton
             label='휴대폰 본인인증'
             onPress={() => {
-              router.push('/auth/phone');
+              router.push('/auth/phone?menu=findPassword');
             }}
             disabled={email.length === 0}
           />

--- a/app/auth/find/password/index.tsx
+++ b/app/auth/find/password/index.tsx
@@ -2,29 +2,25 @@ import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
 import { LongButton } from '@/components/common/buttons/LongButton';
 import { TextField } from '@/components/common/Inputs/TextField';
 import Navigation from '@/components/layout/Navigation';
+import DefaultModal from '@/components/common/modals/DefaultModal';
 import { isEmail } from '@/utils/validation';
 import { Stack, useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Alert, Pressable, SafeAreaView, Text, View } from 'react-native';
+import { Pressable, SafeAreaView, Text, View } from 'react-native';
 import { usePasswordReset } from '@/store/usePasswordReset';
 import { useCheckEmailExists } from '@/hooks/auth/useCheckExistsEmail';
-import DefaultModal from '@/components/common/modals/DefaultModal';
+
 export default function Index() {
   const router = useRouter();
 
-  const [isEmailValid, setIsEmailValid] = useState(false);
-  const { email, setEmail } = usePasswordReset();
-  const [isExistsEmail, setIsExistsEmail] = useState(false);
+  const { email, setEmail, clear } = usePasswordReset();
   const [visibleModal, setVisibleModal] = useState(false);
+
   const { mutate: checkEmail, isPending } = useCheckEmailExists({
     onSuccess: (res) => {
       if (res.exists) {
-        setIsExistsEmail(true);
-        setVisibleModal(false);
         router.push('/auth/phone?menu=findPassword');
       } else {
-        console.log(res.exists);
-        setIsExistsEmail(false);
         setVisibleModal(true);
       }
     },
@@ -32,21 +28,13 @@ export default function Index() {
       const msg =
         // @ts-ignore
         err?.response?.data?.message || '이메일 확인 중 오류가 발생했습니다.';
-      Alert.alert(msg);
+      console.log(msg);
     },
   });
-  const validateEmail = (value: string) => {
-    const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return regex.test(value);
-  };
 
   useEffect(() => {
-    if (!validateEmail(email)) {
-      setIsEmailValid(true);
-    } else {
-      setIsEmailValid(false);
-    }
-  }, [email]);
+    clear();
+  }, [clear]);
 
   const handlePhoneAuthPress = () => {
     checkEmail({ email });
@@ -82,9 +70,9 @@ export default function Index() {
         </View>
         <View className='mb-[25px]'>
           <LongButton
-            label='휴대폰 본인인증'
+            label={isPending ? '확인 중...' : '휴대폰 본인인증'}
             onPress={handlePhoneAuthPress}
-            disabled={email.length === 0}
+            disabled={!isEmail(email) || isPending}
           />
         </View>
         <View className='flex-row items-center justify-center mt-[10px]'>

--- a/app/auth/find/password/index.tsx
+++ b/app/auth/find/password/index.tsx
@@ -5,15 +5,36 @@ import Navigation from '@/components/layout/Navigation';
 import { isEmail } from '@/utils/validation';
 import { Stack, useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Pressable, SafeAreaView, Text, View } from 'react-native';
+import { Alert, Pressable, SafeAreaView, Text, View } from 'react-native';
 import { usePasswordReset } from '@/store/usePasswordReset';
-
+import { useCheckEmailExists } from '@/hooks/auth/useCheckExistsEmail';
+import DefaultModal from '@/components/common/modals/DefaultModal';
 export default function Index() {
   const router = useRouter();
 
   const [isEmailValid, setIsEmailValid] = useState(false);
   const { email, setEmail } = usePasswordReset();
-  // 이메일 형식 체크
+  const [isExistsEmail, setIsExistsEmail] = useState(false);
+  const [visibleModal, setVisibleModal] = useState(false);
+  const { mutate: checkEmail, isPending } = useCheckEmailExists({
+    onSuccess: (res) => {
+      if (res.exists) {
+        setIsExistsEmail(true);
+        setVisibleModal(false);
+        router.push('/auth/phone?menu=findPassword');
+      } else {
+        console.log(res.exists);
+        setIsExistsEmail(false);
+        setVisibleModal(true);
+      }
+    },
+    onError: (err) => {
+      const msg =
+        // @ts-ignore
+        err?.response?.data?.message || '이메일 확인 중 오류가 발생했습니다.';
+      Alert.alert(msg);
+    },
+  });
   const validateEmail = (value: string) => {
     const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return regex.test(value);
@@ -27,6 +48,10 @@ export default function Index() {
     }
   }, [email]);
 
+  const handlePhoneAuthPress = () => {
+    checkEmail({ email });
+  };
+
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
@@ -34,7 +59,6 @@ export default function Index() {
         left={<ArrowLeftIcon width={20} height={20} />}
         onLeftPress={() => router.back()}
       />
-
       <View className='p-5'>
         <Text className='text-h-lg font-extrabold text-gray-700 mb-[12px]'>
           비밀번호 변경
@@ -59,9 +83,7 @@ export default function Index() {
         <View className='mb-[25px]'>
           <LongButton
             label='휴대폰 본인인증'
-            onPress={() => {
-              router.push('/auth/phone?menu=findPassword');
-            }}
+            onPress={handlePhoneAuthPress}
             disabled={email.length === 0}
           />
         </View>
@@ -80,6 +102,21 @@ export default function Index() {
           </Pressable>
         </View>
       </View>
+      {visibleModal && (
+        <DefaultModal
+          visible={visibleModal}
+          onConfirm={() => {
+            setVisibleModal(false);
+            router.push('/auth/signUp');
+          }}
+          onCancel={() => setVisibleModal(false)}
+          title='계정을 찾을 수 없습니다.'
+          message='해당 정보로 가입된 계정을 찾을 수 없습니다.'
+          secondMessage='다시 한번 확인해주시거나, 회원가입을 진행해주세요.'
+          confirmText='회원가입'
+          cancelText='처음으로'
+        />
+      )}
     </SafeAreaView>
   );
 }

--- a/app/auth/login/index.tsx
+++ b/app/auth/login/index.tsx
@@ -61,7 +61,7 @@ export default function Index() {
 
         <View className='flex-row items-center justify-center mt-[10px]'>
           <Text className='text-b-sm font-bold text-gray-500'>
-            서비스가 궁굼하시다면?
+            서비스가 궁금하시다면?
           </Text>
           <Pressable
             onPress={() => {

--- a/app/auth/phone/index.tsx
+++ b/app/auth/phone/index.tsx
@@ -2,13 +2,18 @@ import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
 import Navigation from '@/components/layout/Navigation';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { Pressable, SafeAreaView, Text, View } from 'react-native';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TextField } from '@/components/common/Inputs/TextField';
 import { LongButton } from '@/components/common/buttons/LongButton';
 import { useMemo } from 'react';
 import DefaultModal from '@/components/common/modals/DefaultModal';
 import { useSignup } from '@/hooks/useSignUp';
 import { useSignupDraft } from '@/store/useSignupDraft';
+import {
+  useSendPhoneAuth,
+  useVerifyAuthCode,
+  useVerifyAuthToken,
+} from '@/hooks/auth/usePhoneAuth';
 
 export default function Index() {
   const { menu } = useLocalSearchParams<{ menu?: string }>();
@@ -18,9 +23,68 @@ export default function Index() {
   const [requestAuthNumber, setRequestAuthNumber] = useState(false);
   const [visibleModal, setVisibleModal] = useState(false);
   const [disabledButton, setDisabledButton] = useState(false);
+  const [verificationToken, setVerificationToken] = useState<string | null>(
+    null,
+  );
+  const [remainSec, setRemainSec] = useState(0);
 
+  const [modalMessage, setModalMessage] =
+    useState('인증번호가 일치하지 않습니다');
+  const EXPIRE_SECONDS = 180;
   const { email, password, confirmPassword, clear } = useSignupDraft();
-  const MOCK_AUTH_NUMBER = '123456';
+
+  // 1) 인증번호 발송 훅
+  const sendPhoneAuthMutation = useSendPhoneAuth({
+    onSuccess: (res) => {
+      setRequestAuthNumber(true); // 입력창 열기
+      setRemainSec(180); // 5분
+    },
+    onError: (err: any) =>
+      console.log('[sendPhoneAuth error]', err?.response?.data),
+  });
+
+  // 2) 인증번호 검증 훅
+  const verifyAuthCodeMutation = useVerifyAuthCode({
+    onSuccess: (data) => {
+      // 서버가 준 verification_token 저장 (필요시 토큰 검증/다음 단계에 활용)
+      setVerificationToken(data.verification_token);
+      onVerified();
+    },
+    onError: () => {
+      setModalMessage('인증번호가 일치하지 않습니다');
+      setVisibleModal(true); // "인증번호 불일치" 모달
+    },
+  });
+  // (선택) 3) 토큰 검증 훅 — 필요 시 사용
+  const verifyAuthTokenMutation = useVerifyAuthToken();
+
+  // 카운트다운
+  useEffect(() => {
+    if (!requestAuthNumber || remainSec <= 0) return;
+    const id = setInterval(() => setRemainSec((s) => s - 1), 1000);
+    return () => clearInterval(id);
+  }, [requestAuthNumber, remainSec]);
+
+  useEffect(() => {
+    if (!requestAuthNumber) return;
+    if (remainSec === 0) {
+      // 단계 롤백 + 입력 초기화
+      setRequestAuthNumber(false); // 번호 입력 단계로 돌아감
+      setAuthNumber('');
+      setVerificationToken(null);
+      // 필요하면 안내 모달/토스트
+      setModalMessage(
+        '인증번호 유효시간이 만료되었습니다.\n다시 요청해 주세요.',
+      );
+      setVisibleModal(true);
+    }
+  }, [requestAuthNumber, remainSec]);
+
+  const remainText = useMemo(() => {
+    const m = Math.floor(remainSec / 60);
+    const s = String(remainSec % 60).padStart(2, '0');
+    return `${m}:${s}`;
+  }, [remainSec]);
 
   const formatPhoneNumber = (phone: string) => {
     const digits = phone.replace(/\D/g, '');
@@ -30,9 +94,6 @@ export default function Index() {
     return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
   };
 
-  const checkAuthNumber = (authNumber: string) => {
-    return authNumber === MOCK_AUTH_NUMBER;
-  };
   const signupMutation = useSignup({
     onSuccess: () => {
       clear();
@@ -41,17 +102,8 @@ export default function Index() {
   });
 
   const canSubmit = useMemo(() => {
-    if (phone.length !== 11 || phone.slice(0, 3) !== '010') {
-      setDisabledButton(true);
-      return false;
-    }
-    if (requestAuthNumber) {
-      if (authNumber.length !== 6) {
-        setDisabledButton(true);
-        return false;
-      }
-    }
-    setDisabledButton(false);
+    if (phone.length !== 11 || phone.slice(0, 3) !== '010') return false;
+    if (requestAuthNumber) return authNumber.length === 6;
     return true;
   }, [phone, authNumber, requestAuthNumber]);
 
@@ -61,11 +113,39 @@ export default function Index() {
         email,
         password,
         password2: confirmPassword,
+        phone_number: phone,
       });
     } else if (menu === 'findPassword') {
       // router.push('/auth/find/result');
     } else if (menu === 'findId') {
       // router.push('/auth/find/id/result');
+    }
+  };
+
+  const isLoading =
+    sendPhoneAuthMutation.isPending || verifyAuthCodeMutation.isPending;
+
+  const handlePress = () => {
+    if (requestAuthNumber) {
+      // ⛔️ 만료 시 검증 막고 모달
+      if (remainSec <= 0) {
+        setModalMessage(
+          '인증번호 유효시간이 만료되었습니다.\n다시 요청해 주세요.',
+        );
+        setVisibleModal(true);
+        return;
+      }
+      // 인증번호 검증 단계
+      verifyAuthCodeMutation.mutate({
+        phoneNumber: phone, // 하이픈 제거 숫자만
+        verificationCode: authNumber, // 6자리
+      });
+
+      // (선택) 토큰을 따로 서버가 검증하라면:
+      // verifyAuthTokenMutation.mutate(verificationToken!)
+    } else {
+      // 인증번호 발송 단계
+      sendPhoneAuthMutation.mutate(phone); // 숫자만 전달
     }
   };
 
@@ -88,6 +168,7 @@ export default function Index() {
           휴대폰 본인인증을 완료하면 가입이 완료됩니다.
         </Text>
 
+        {/* 휴대폰 번호 */}
         <TextField
           menu={1}
           value={formatPhoneNumber(phone)}
@@ -96,45 +177,65 @@ export default function Index() {
           }
           placeholder='휴대폰 번호를 입력해주세요.'
           keyboardType='number-pad'
-          disabled={requestAuthNumber}
+          disabled={requestAuthNumber || isLoading}
         />
+
+        {/* 인증번호 입력 (발송 후에만 노출) */}
         {requestAuthNumber && (
-          <TextField
-            menu={1}
-            value={authNumber}
-            onChangeText={(text) =>
-              setAuthNumber(text.replace(/\D/g, '').slice(0, 6))
-            }
-            placeholder='인증번호를 입력해주세요.'
-            keyboardType='number-pad'
-          />
-        )}
-        <View className='mt-[30px]'>
-          <LongButton
-            label={requestAuthNumber ? '본인 인증 완료' : '인증 번호 요청'}
-            onPress={() => {
-              // router.push('/auth/find/id/result');
-              if (requestAuthNumber) {
-                // 인증번호 확인
-                if (checkAuthNumber(authNumber)) {
-                  onVerified();
-                } else {
-                  setVisibleModal(true);
-                }
-              } else {
-                setRequestAuthNumber(true);
+          <>
+            <TextField
+              menu={1}
+              value={authNumber}
+              onChangeText={(text) =>
+                setAuthNumber(text.replace(/\D/g, '').slice(0, 6))
               }
-            }}
-            disabled={disabledButton || !canSubmit}
+              placeholder='인증번호를 입력해주세요.'
+              keyboardType='number-pad'
+              disabled={isLoading}
+            />
+            {authNumber.length < 6 && (
+              <View className=' ml-[17px]'>
+                <Text className='text-c2 text-[#FF3A4A]'>
+                  유효시간 {remainText}
+                </Text>
+              </View>
+            )}
+          </>
+        )}
+
+        <View className='mt-[25px]'>
+          <LongButton
+            label={
+              isLoading
+                ? '처리 중...'
+                : requestAuthNumber
+                  ? '본인 인증 완료'
+                  : '인증 번호 요청'
+            }
+            onPress={handlePress}
+            disabled={disabledButton || !canSubmit || isLoading}
           />
         </View>
       </View>
+      {requestAuthNumber && (
+        <View className='flex-row items-center justify-center'>
+          <View className='flex-row '>
+            <Text className='text-b-sm font-bold text-gray-500 mr-2'>
+              인증번호를 받지 못하셨나요?
+            </Text>
+            <Pressable onPress={handlePress}>
+              <Text className='text-b-md font-extrabold text-[#19B375]'>
+                재전송
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
       <DefaultModal
         visible={visibleModal}
         onConfirm={() => setVisibleModal(false)}
         onCancel={() => setVisibleModal(false)}
-        // title='인증번호가 일치하지 않습니다.'
-        message='인증번호가 일치하지 않습니다'
+        message={modalMessage}
         confirmText='확인'
         singleButton
       />

--- a/app/auth/phone/index.tsx
+++ b/app/auth/phone/index.tsx
@@ -171,6 +171,28 @@ export default function Index() {
     }
   };
 
+  const handleResend = () => {
+    if (!phone || phone.length !== 11) {
+      setModalMessage('휴대폰 번호를 올바르게 입력해 주세요.');
+      setVisibleModal(true);
+      return;
+    }
+
+    // 이전 시도 상태 초기화
+    verifyAuthCodeMutation.reset();
+    setAuthNumber('');
+    setVerificationToken(null);
+    setVisibleModal(false);
+
+    // 재전송
+    sendPhoneAuthMutation.mutate(phone, {
+      onSuccess: (res) => {
+        setRequestAuthNumber(true);
+        setRemainSec(EXPIRE_SECONDS); // 서버값 있으면 사용
+      },
+    });
+  };
+
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
@@ -245,7 +267,7 @@ export default function Index() {
             <Text className='text-b-sm font-bold text-gray-500 mr-2'>
               인증번호를 받지 못하셨나요?
             </Text>
-            <Pressable onPress={handlePress}>
+            <Pressable onPress={handleResend}>
               <Text className='text-b-md font-extrabold text-[#19B375]'>
                 재전송
               </Text>

--- a/app/auth/phone/index.tsx
+++ b/app/auth/phone/index.tsx
@@ -113,12 +113,14 @@ export default function Index() {
         email,
         password,
         password2: confirmPassword,
-        phone_number: phone,
+        phoneNumber: phone,
       });
     } else if (menu === 'findPassword') {
       // router.push('/auth/find/result');
     } else if (menu === 'findId') {
       // router.push('/auth/find/id/result');
+      router.push('/auth/find/id/result');
+
     }
   };
 

--- a/hooks/auth/useCheckExistsEmail.ts
+++ b/hooks/auth/useCheckExistsEmail.ts
@@ -1,0 +1,32 @@
+// hooks/auth/useCheckEmail.ts
+import { useMutation } from '@tanstack/react-query';
+import { Alert } from 'react-native';
+import {
+  checkEmailExists,
+  CheckEmailRequest,
+  CheckEmailResponse,
+} from '@/services/auth/checkEmailExists';
+
+/**
+ * 이메일 중복/존재 여부 확인 훅
+ * - mutate({ email }) 로 호출
+ * - onSuccess, onError 옵션으로 후처리 주입 가능
+ */
+export const useCheckEmailExists = (opts?: {
+  onSuccess?: (data: CheckEmailResponse) => void;
+  onError?: (err: unknown) => void;
+}) =>
+  useMutation<CheckEmailResponse, unknown, CheckEmailRequest>({
+    mutationFn: checkEmailExists,
+    onSuccess: (data) => {
+      opts?.onSuccess?.(data);
+    },
+    onError: (err: any) => {
+      const msg =
+        err?.response?.data?.message ||
+        err?.response?.data?.detail ||
+        '이메일 확인 중 오류가 발생했어요.';
+      console.log('msg', msg);
+      opts?.onError?.(err);
+    },
+  });

--- a/hooks/auth/useFindAccount.ts
+++ b/hooks/auth/useFindAccount.ts
@@ -1,10 +1,16 @@
 // hooks/auth/useFindIDWithPhone.ts
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import {
   findIDWithPhone,
   findIDWithPhoneResponse,
 } from '@/services/auth/findIDWithPhone';
+
+import {
+  ResetPasswordResponse,
+  resetPasswordConfirm,
+  ResetPasswordRequest,
+} from '@/services/auth/changePWwithEmail';
 
 type Options = {
   enabled?: boolean;
@@ -42,3 +48,17 @@ export const useFindIDWithPhone = (phone_number: string, opts?: Options) => {
 
   return query;
 };
+
+export const useResetPassword = (opts?: {
+  onSuccess?: (data: ResetPasswordResponse) => void;
+  onError?: (err: unknown) => void;
+}) =>
+  useMutation<ResetPasswordResponse, unknown, ResetPasswordRequest>({
+    mutationFn: resetPasswordConfirm,
+    onSuccess: (data) => {
+      opts?.onSuccess?.(data);
+    },
+    onError: (err) => {
+      opts?.onError?.(err);
+    },
+  });

--- a/hooks/auth/useFindAccount.ts
+++ b/hooks/auth/useFindAccount.ts
@@ -1,0 +1,44 @@
+// hooks/auth/useFindIDWithPhone.ts
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import {
+  findIDWithPhone,
+  findIDWithPhoneResponse,
+} from '@/services/auth/findIDWithPhone';
+
+type Options = {
+  enabled?: boolean;
+  onSuccess?: (data: findIDWithPhoneResponse) => void;
+  onError?: (err: unknown) => void;
+};
+
+/**
+ * 휴대폰 번호로 계정 찾기 훅 (TanStack Query v5)
+ * - v5는 useQuery 옵션에 onSuccess/onError가 없어서 useEffect로 처리합니다.
+ */
+
+export const useFindIDWithPhone = (phone_number: string, opts?: Options) => {
+  const query = useQuery<findIDWithPhoneResponse, unknown>({
+    queryKey: ['findIDWithPhone', phone_number],
+    queryFn: () => findIDWithPhone(phone_number),
+    enabled: opts?.enabled ?? Boolean(phone_number),
+  });
+
+  // 성공 시 콜백
+  useEffect(() => {
+    if (query.isSuccess && query.data && opts?.onSuccess) {
+      opts.onSuccess(query.data);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.isSuccess, query.data]);
+
+  // 에러 시 콜백
+  useEffect(() => {
+    if (query.isError && query.error && opts?.onError) {
+      opts.onError(query.error);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.isError, query.error]);
+
+  return query;
+};

--- a/hooks/auth/usePhoneAuth.ts
+++ b/hooks/auth/usePhoneAuth.ts
@@ -1,0 +1,65 @@
+// hooks/usePhoneAuth.ts
+import { useMutation } from '@tanstack/react-query';
+import {
+  sendPhoneAuth,
+  verifyAuthCode,
+  verifyAuthToken,
+  sendPhoneAuthResponse,
+  verifyAuthCodeResponse,
+  verifyAuthTokenResponse,
+} from '@/services/auth/phone/phoneAuth';
+
+// 전화번호 인증 발송 훅
+export const useSendPhoneAuth = (opts?: {
+  onSuccess?: (data: sendPhoneAuthResponse) => void;
+  onError?: (err: unknown) => void;
+}) =>
+  useMutation<sendPhoneAuthResponse, unknown, string>({
+    mutationFn: (phoneNumber: string) => sendPhoneAuth(phoneNumber),
+    onSuccess: (data) => {
+      opts?.onSuccess?.(data);
+    },
+    onError: (err: any) => {
+      console.log('인증번호 발송 실패:', err.response?.data);
+      opts?.onError?.(err);
+    },
+  });
+
+// 인증번호 검증 훅
+export const useVerifyAuthCode = (opts?: {
+  onSuccess?: (data: verifyAuthCodeResponse) => void;
+  onError?: (err: unknown) => void;
+}) =>
+  useMutation<
+    verifyAuthCodeResponse,
+    unknown,
+    { phoneNumber: string; verificationCode: string }
+  >({
+    mutationFn: ({ phoneNumber, verificationCode }) =>
+      verifyAuthCode(phoneNumber, verificationCode),
+    onSuccess: (data) => {
+      opts?.onSuccess?.(data);
+    },
+    onError: (err: any) => {
+      console.log('인증 실패:', err.response?.data);
+
+      opts?.onError?.(err);
+    },
+  });
+
+// 인증 토큰 검증 훅
+export const useVerifyAuthToken = (opts?: {
+  onSuccess?: (data: verifyAuthTokenResponse) => void;
+  onError?: (err: unknown) => void;
+}) =>
+  useMutation<verifyAuthTokenResponse, unknown, string>({
+    mutationFn: (verificationToken: string) =>
+      verifyAuthToken(verificationToken),
+    onSuccess: (data) => {
+      opts?.onSuccess?.(data);
+    },
+    onError: (err: any) => {
+      console.log('토큰 검증 실패:', err.response?.data);
+      opts?.onError?.(err);
+    },
+  });

--- a/hooks/useReportReview.ts
+++ b/hooks/useReportReview.ts
@@ -1,0 +1,49 @@
+// hooks/product/review/useReportReview.ts
+import { useMutation } from '@tanstack/react-query';
+import { Alert } from 'react-native';
+import { reportReview, ReportRequest, ReportResponse } from '@/services/report';
+
+type Vars = { reviewId: number; reason: ReportRequest['reason'] };
+
+export function useReportReview(opts?: {
+  onSuccess?: (data: ReportResponse, vars: Vars) => void;
+  onError?: (err: unknown, vars: Vars) => void;
+}) {
+  return useMutation<ReportResponse, unknown, Vars>({
+    mutationFn: async ({ reviewId, reason }) =>
+      reportReview(reviewId, { reason }),
+    onSuccess: (data, vars) => {
+      // 서버 메시지 우선, 없으면 기본 문구
+      const msg =
+        data?.message ||
+        data?.detail ||
+        '신고가 접수되었습니다. 검토 후 조치될 예정이에요.';
+      Alert.alert('신고 완료', msg);
+      opts?.onSuccess?.(data, vars);
+    },
+    onError: (err: any, vars) => {
+      // 상태/본문에 따라 사용자 친화적으로 메시지 생성
+      const status = err?.response?.status;
+      const body = err?.response?.data;
+
+      let msg =
+        (typeof body === 'string' && body) ||
+        body?.message ||
+        body?.detail ||
+        '신고 처리 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.';
+
+      // 동일 사용자 중복 신고 케이스 대비(서버가 400/409를 줄 가능성)
+      if (status === 400 || status === 409) {
+        // 서버가 특정 키워드를 주면 그대로 보여주고, 없으면 친절 메시지
+        if (/already/i.test(msg) || /중복|이미 신고/i.test(msg)) {
+          // 그대로 둠
+        } else {
+          msg = '이미 이 리뷰를 신고하셨어요.';
+        }
+      }
+
+      Alert.alert(msg);
+      opts?.onError?.(err, vars);
+    },
+  });
+}

--- a/hooks/useSignUp.tsx
+++ b/hooks/useSignUp.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { signUp, SignUpRequest, SignUpResponse } from '../services/auth/signUp';
+import { Alert } from 'react-native';
 
 export const useSignup = (opts?: {
   onSuccess?: (data: SignUpResponse) => void;
@@ -24,8 +25,10 @@ export const useSignup = (opts?: {
             return `${field} : ${messages}`;
           })
           .join('\n\n');
+        Alert.alert(msg);
       } else if (typeof err?.response?.data === 'string') {
         msg = err.response.data;
+        Alert.alert(msg);
       }
 
       opts?.onError?.(err);

--- a/services/auth/changePWwithEmail.ts
+++ b/services/auth/changePWwithEmail.ts
@@ -1,0 +1,24 @@
+import { axiosInstance } from '../index';
+
+export type ResetPasswordRequest = {
+  email: string;
+  new_password1: string;
+  new_password2: string;
+  verification_token: string;
+};
+export type ResetPasswordResponse = {
+  success: boolean;
+  email: string;
+  user_id: number;
+  message: string;
+};
+
+export async function resetPasswordConfirm(
+  body: ResetPasswordRequest,
+): Promise<ResetPasswordResponse> {
+  const { data } = await axiosInstance.post<ResetPasswordResponse>(
+    '/auth/email/password/reset/',
+    body,
+  );
+  return data;
+}

--- a/services/auth/checkEmailExists.ts
+++ b/services/auth/checkEmailExists.ts
@@ -1,0 +1,24 @@
+// services/auth/checkEmail.ts
+import { axiosInstance } from '../index';
+
+export type CheckEmailRequest = {
+  email: string;
+};
+
+export type CheckEmailResponse = {
+  success: boolean;
+  email: string;
+  exists: boolean;
+  message: string;
+};
+
+/** 이메일 존재 여부 확인 */
+export async function checkEmailExists(
+  payload: CheckEmailRequest,
+): Promise<CheckEmailResponse> {
+  const { data } = await axiosInstance.post<CheckEmailResponse>(
+    '/auth/email/check/',
+    payload,
+  );
+  return data;
+}

--- a/services/auth/findIDWithPhone.ts
+++ b/services/auth/findIDWithPhone.ts
@@ -1,0 +1,20 @@
+// services/auth/signIn.ts
+import { axiosInstance } from '../index';
+
+export type findIDWithPhoneResponse = {
+  sucesss: boolean;
+  phone_number: string;
+  accounts: [{ email: string; created_at: null | string }]; //login_type 없음 (추후 추가)
+  message: string;
+};
+
+// 전화번호 인증 발송
+export async function findIDWithPhone(
+  phone_number: string,
+): Promise<findIDWithPhoneResponse> {
+  const { data } = await axiosInstance.get<findIDWithPhoneResponse>(
+    `/auth/phone/account-info`,
+    { params: { phone_number } },
+  );
+  return data;
+}

--- a/services/auth/phone/phoneAuth.ts
+++ b/services/auth/phone/phoneAuth.ts
@@ -1,0 +1,60 @@
+// services/auth/signIn.ts
+import { axiosInstance } from '../../index';
+
+export type sendPhoneAuthResponse = {
+  success: boolean;
+  original_phone: string;
+  parsed_phone: string;
+  message: string;
+  remaining_requests: number;
+  sent_at: string;
+  verification_code: string;
+};
+
+export type verifyAuthTokenResponse = {
+  valid: boolean;
+  phone_number: string;
+  expires_at: string;
+};
+
+export type verifyAuthCodeResponse = {
+  success: boolean;
+  message: string;
+  verification_token: string;
+  expires_at: string;
+  expires_in_seconds: number;
+};
+
+// 전화번호 인증 발송
+export async function sendPhoneAuth(
+  phone_number: string,
+): Promise<sendPhoneAuthResponse> {
+  const { data } = await axiosInstance.post<sendPhoneAuthResponse>(
+    '/auth/send/',
+    { phone_number },
+  );
+  return data;
+}
+
+// 인증 토큰 검증
+export async function verifyAuthToken(
+  verification_token: string,
+): Promise<verifyAuthTokenResponse> {
+  const { data } = await axiosInstance.post<verifyAuthTokenResponse>(
+    '/auth/token/verify/',
+    { verification_token },
+  );
+  return data;
+}
+
+// 인증번호 검증
+export async function verifyAuthCode(
+  phone_number: string,
+  verification_code: string,
+): Promise<verifyAuthCodeResponse> {
+  const { data } = await axiosInstance.post<verifyAuthCodeResponse>(
+    '/auth/verify/',
+    { phone_number, verification_code },
+  );
+  return data;
+}

--- a/services/auth/signUp.ts
+++ b/services/auth/signUp.ts
@@ -4,6 +4,7 @@ export type SignUpRequest = {
   email: string;
   password: string;
   password2: string;
+  phone_number: string;
 };
 
 export type SignUpResponse = {

--- a/services/auth/signUp.ts
+++ b/services/auth/signUp.ts
@@ -4,12 +4,13 @@ export type SignUpRequest = {
   email: string;
   password: string;
   password2: string;
-  phone_number: string;
+  phoneNumber: string;
 };
 
 export type SignUpResponse = {
   id: number;
   email: string;
+  phoneNumber: string;
 };
 
 export async function signUp(data: SignUpRequest): Promise<SignUpResponse> {

--- a/services/report.ts
+++ b/services/report.ts
@@ -1,0 +1,34 @@
+// services/auth/signIn.ts
+import { axiosInstance } from './index';
+
+export type ReportReason =
+  | 'IRRELEVANT'
+  | 'MISMATCH'
+  | 'PROMOTION'
+  | 'ABUSE'
+  | 'PRIVACY';
+
+export type ReportRequest = {
+  reason: ReportReason;
+};
+
+export type ReportResponse = {
+  // 서버 스펙이 고정돼 있지 않을 수 있으니 확장 가능하게 둔다
+  message?: string;
+  detail?: string;
+  success?: boolean;
+  reported?: boolean;
+  count?: number; // 누적 신고 수 등을 내려줄 수도 있음
+};
+
+export async function reportReview(
+  reviewId: number,
+  req: ReportRequest,
+): Promise<ReportResponse> {
+  console.log('[reportReview] POST', `/review/${reviewId}/report/`, req);
+  const { data } = await axiosInstance.post<ReportResponse>(
+    `/review/${reviewId}/report/`,
+    req,
+  );
+  return data ?? {};
+}

--- a/store/useFoundAccounts.ts
+++ b/store/useFoundAccounts.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+type Account = {
+  email: string;
+  created_at: string | null;
+  login_type?: string;
+};
+
+type FoundAccountsState = {
+  phone: string;
+  accounts: Account[];
+  setFound: (phone: string, accounts: Account[]) => void;
+  clear: () => void;
+};
+
+export const useFoundAccounts = create<FoundAccountsState>((set) => ({
+  phone: '',
+  accounts: [],
+  setFound: (phone, accounts) => set({ phone, accounts }),
+  clear: () => set({ phone: '' }),
+}));

--- a/store/usePasswordReset.ts
+++ b/store/usePasswordReset.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+type PasswordResetState = {
+  email: string;
+  verificationToken: string | null;
+  setEmail: (v: string) => void;
+  setVerificationToken: (v: string | null) => void;
+  clear: () => void;
+};
+
+export const usePasswordReset = create<PasswordResetState>((set) => ({
+  email: '',
+  verificationToken: null,
+  setEmail: (email) => set({ email }),
+  setVerificationToken: (verificationToken) => set({ verificationToken }),
+  clear: () => set({ email: '', verificationToken: null }),
+}));


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
#30 
#35
## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 신고하기 api 연동
- 휴대폰 본인인증 api 연동
- 이메일 존재 확인 api 연동
- 이메일 기반 비밀번호 변경 api 연동
- 계정찾기 api 연동
- 회원가입 시 휴대폰 번호를 api 파라미터에 포함

## 🗣️ 팀원에게 공유할 내용

- 계정 찾기에서 받은 데이터 (email, created_at, , phone, login_type)를 store/useFoundAccounts.ts 에 zustand 이용하여 저장해 사용하였습니다.
- 비밀번호 변경 시 필요한 데이터(email, verificationToken) 를 store/usePasswordReset.ts에 에 zustand 이용하여 저장해 사용하였습니다.

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->