### PR TITLE
fix: 애플 사진/카메라 접근 권한 문수 설정

### DIFF
--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -46,13 +46,13 @@
       <true/>
     </dict>
     <key>NSCameraUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your camera</string>
+    <string>제품 리뷰를 작성할 때 직접 촬영한 사진을 첨부하기 위해 카메라를 사용합니다.</string>
     <key>NSFaceIDUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your microphone</string>
     <key>NSPhotoLibraryUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your photos</string>
+    <string>리뷰 작성 시 기기에 저장된 사진을 선택해 첨부하기 위해 사진 보관함에 접근합니다.</string>
     <key>NSUserActivityTypes</key>
     <array>
       <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- ios info.plist에 사진 접근/ 카메라 접근 권한 문구 변경하였습니다.

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->