### PR TITLE
Feat: price 안보이도록 수정

### DIFF
--- a/app/(tabs)/category/list.tsx
+++ b/app/(tabs)/category/list.tsx
@@ -110,8 +110,8 @@ export default function List() {
   const sortOptions = [
     { id: 'monthly_rank', label: '랭킹순' },
     { id: 'review_desc', label: '리뷰순' },
-    { id: 'price_asc', label: '낮은 가격순' },
-    { id: 'price_desc', label: '높은 가격순' },
+    // { id: 'price_asc', label: '낮은 가격순' },
+    // { id: 'price_desc', label: '높은 가격순' },
   ];
 
   const {
@@ -127,8 +127,8 @@ export default function List() {
     smallCategory: tab,
     sort: selectedSort as
       | 'monthly_rank'
-      | 'price_asc'
-      | 'price_desc'
+      // | 'price_asc'
+      // | 'price_desc'
       | 'review_desc',
   });
 

--- a/app/home/search.tsx
+++ b/app/home/search.tsx
@@ -29,8 +29,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 const sortOptions = [
   { id: 'monthly_rank', label: '랭킹순' },
   { id: 'review_desc', label: '리뷰순' },
-  { id: 'price_asc', label: '낮은 가격순' },
-  { id: 'price_desc', label: '높은 가격순' },
+  // { id: 'price_asc', label: '낮은 가격순' },
+  // { id: 'price_desc', label: '높은 가격순' },
 ];
 
 import { useSearchProductsQuery } from '@/hooks/useProductQueries';
@@ -65,8 +65,8 @@ export default function Search() {
     word: searchQuery,
     sort: selectedSort as
       | 'monthly_rank'
-      | 'price_asc'
-      | 'price_desc'
+      // | 'price_asc'
+      // | 'price_desc'
       | 'review_desc',
   });
 

--- a/app/product/[id]/productDetail.tsx
+++ b/app/product/[id]/productDetail.tsx
@@ -192,9 +192,11 @@ export default function ProductDetail() {
                   </View>
                   <View className='flex-row items-center'>
                     <Text className='text-b-lg font-n-bd'>정가 </Text>
-                    <Text className='text-h-md font-n-eb'>
-                      {data?.price.toLocaleString('ko-KR') ?? 0}원{' '}
-                    </Text>
+                    {data?.price ? (
+                      <Text className='text-h-md font-n-eb'>
+                        {data.price.toLocaleString('ko-KR')}원{' '}
+                      </Text>
+                    ) : null}
                     <Text className='text-c1 font-n-bd text-gray-300'>
                       / {data?.unit ?? ''}
                     </Text>

--- a/components/page/home/ProductCard.tsx
+++ b/components/page/home/ProductCard.tsx
@@ -103,25 +103,37 @@ export default function ProductCard({
           </View>
 
           <View style={{ flexDirection: 'row', alignItems: 'baseline' }}>
-            <Text
-              style={{ fontSize: 12, color: colors.gray[900], marginRight: 2 }}
-            >
-              정가
-            </Text>
-            <Text
-              style={{
-                fontSize: 14,
-                fontWeight: '400',
-                color: colors.gray[900],
-              }}
-            >
-              {item.price.toLocaleString('ko-KR')}원
-            </Text>
-            <Text
-              style={{ fontSize: 11, color: colors.gray[400], marginLeft: 4 }}
-            >
-              / {item.unit}
-            </Text>
+            {item.price ? (
+              <>
+                <Text
+                  style={{
+                    fontSize: 12,
+                    color: colors.gray[900],
+                    marginRight: 2,
+                  }}
+                >
+                  정가
+                </Text>
+                <Text
+                  style={{
+                    fontSize: 14,
+                    fontWeight: '400',
+                    color: colors.gray[900],
+                  }}
+                >
+                  {item.price.toLocaleString('ko-KR')}원
+                </Text>
+                <Text
+                  style={{
+                    fontSize: 11,
+                    color: colors.gray[400],
+                    marginLeft: 4,
+                  }}
+                >
+                  / {item.unit}
+                </Text>
+              </>
+            ) : null}
           </View>
         </View>
       </View>

--- a/components/page/home/ProductCarousel.tsx
+++ b/components/page/home/ProductCarousel.tsx
@@ -47,9 +47,11 @@ export default function ProductCarousel({ data }: ProductCarouselProps) {
         <Text className='text-yellow-star text-xs'>★</Text>
         <Text className='text-xs text-gray-600'>{item.rating} (리뷰수)</Text>
       </View>
-      <Text className='text-sm text-gray-900 font-semibold'>
-        정가 {item.price.toLocaleString('ko-KR')}
-      </Text>
+      {item.price ? (
+        <Text className='text-sm text-gray-900 font-semibold'>
+          정가 {item.price.toLocaleString('ko-KR')}
+        </Text>
+      ) : null}
     </View>
   );
 

--- a/components/page/home/ProductListRow.tsx
+++ b/components/page/home/ProductListRow.tsx
@@ -69,21 +69,29 @@ export default function ProductListRow({ item, onPress }: Props) {
               alignItems: 'baseline',
             }}
           >
-            <Text
-              style={{ fontSize: 12, color: colors.gray[900], marginRight: 2 }}
-            >
-              정가
-            </Text>
-            <Text
-              style={{
-                fontSize: 14,
-                fontWeight: '400',
-                color: colors.gray[900],
-              }}
-            >
-              {item.price.toLocaleString('ko-KR')}원
-            </Text>
-            <Text className='text-xs text-gray-300'> / {item.unit}</Text>
+            {item.price ? (
+              <>
+                <Text
+                  style={{
+                    fontSize: 12,
+                    color: colors.gray[900],
+                    marginRight: 2,
+                  }}
+                >
+                  정가
+                </Text>
+                <Text
+                  style={{
+                    fontSize: 14,
+                    fontWeight: '400',
+                    color: colors.gray[900],
+                  }}
+                >
+                  {item.price.toLocaleString('ko-KR')}원
+                </Text>
+                <Text className='text-xs text-gray-300'> / {item.unit}</Text>
+              </>
+            ) : null}
           </View>
         </View>
       </View>

--- a/components/page/home/ProductRankingCarousel.tsx
+++ b/components/page/home/ProductRankingCarousel.tsx
@@ -99,10 +99,14 @@ export default function ProductRankingCarousel({ data, isLoading }: Props) {
             </View>
 
             <View style={{ flexDirection: 'row', alignItems: 'baseline' }}>
-              <Text className='mr-1 text-sm font-n-rg'>정가</Text>
-              <Text className='text-base text-gray-900 mr-1 font-n-rg'>
-                {item.price.toLocaleString('ko-KR')}원
-              </Text>
+              {item.price ? (
+                <>
+                  <Text className='mr-1 text-sm font-n-rg'>정가</Text>
+                  <Text className='text-base text-gray-900 mr-1 font-n-rg'>
+                    {item.price.toLocaleString('ko-KR')}원
+                  </Text>
+                </>
+              ) : null}
             </View>
           </View>
         </View>

--- a/components/page/home/RankingItem.tsx
+++ b/components/page/home/RankingItem.tsx
@@ -91,11 +91,15 @@ export default function RankingItem({
           </View>
 
           <View style={{ flexDirection: 'row', alignItems: 'baseline' }}>
-            <Text className='mr-1 text-sm'>정가</Text>
-            <Text className='text-base text-gray-900 mr-1'>
-              {item.price.toLocaleString('ko-KR')}원
-            </Text>
-            <Text className='text-xs text-gray-300'>/ {item.unit}</Text>
+            {item.price ? (
+              <>
+                <Text className='mr-1 text-sm'>정가</Text>
+                <Text className='text-base text-gray-900 mr-1'>
+                  {item.price.toLocaleString('ko-KR')}원
+                </Text>
+                <Text className='text-xs text-gray-300'>/ {item.unit}</Text>
+              </>
+            ) : null}
           </View>
         </View>
 


### PR DESCRIPTION
## 🔗 관련 이슈

- #97

## 📌 PR 내용
- `app/(taps)/category/list.tsx`, `app/home/search.tsx`
    - sort에서 가격 정렬 부분을 주석 처리
- `app/product/[id]/productDetail.tsx`
    - `{data?.price ? ( ... ) : null }`
    - price 정보가 0, null, undefined 중 하나인 경우, 렌더링을 하지 않도록(`null`) 수정
    - 백에서 price를 0으로 받으면 or 프론트에서 price를 0으로 강제해두면 안보임
- 위와 동일하게 수정
    - `components/page/home/ProductCard.tsx`
    - `components/page/home/ProductCarousel.tsx`
    - `components/page/home/ProductListRow.tsx`
    - `components/page/home/ProductRankingCarousel.tsx`
    - `components/page/home/RankingItem.tsx`

## 🗣️ 팀원에게 공유할 내용
- 화면 확인을 아직 못함