### PR TITLE
feat: coupang link (#101)

### DIFF
--- a/app/product/[id]/coupangPartnerScreen.tsx
+++ b/app/product/[id]/coupangPartnerScreen.tsx
@@ -1,0 +1,52 @@
+import CloseIcon from '@/assets/icons/ic_x.svg';
+import { router, useLocalSearchParams } from 'expo-router';
+import { TouchableOpacity, View } from 'react-native';
+
+export default function CoupangPartnerScreen() {
+  const { id, coupangUrl } = useLocalSearchParams<{
+    id: string;
+    coupangUrl: string;
+  }>();
+
+  // const handleGoToCoupang = () => {
+  //   Linking.openURL(productUrl).catch((err) =>
+  //     console.error('쿠팡 링크 이동 실패:', err),
+  //   );
+  // };
+
+  return (
+    <View className='flex-1 bg-white '>
+      <View className='flex-row mt-10 justify-end p-4'>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          className='w-6 h-6 items-center justify-center'
+        >
+          <CloseIcon />
+        </TouchableOpacity>
+      </View>
+
+      <View className='flex-1 items-center pt-[80px]'>
+        {/* {!imageUrl && (
+          <View className='w-[300px] h-[300px] flex justify-center items-center rounded-3xl mt-20 bg-gray-50'>
+            <Text className='text-gray-400'>이미지 준비중입니다.</Text>
+          </View>
+        )}
+        {imageUrl && (
+          <Pressable onPress={() => Linking.openURL(productUrl)}>
+            <View className='relative'>
+              <Image
+                className='w-[240px] h-[480px] resize-contain'
+                src={imageUrl}
+              />
+              <View className='absolute w-[240px] h-[480px] inset-0 border-2 border-white pointer-events-none' />
+            </View>
+          </Pressable>
+        )} */}
+      </View>
+
+      {/* <View className='px-6 mb-12'>
+        <LongButton label='쇼핑하기' onPress={handleGoToCoupang} />
+      </View> */}
+    </View>
+  );
+}

--- a/app/product/[id]/productDetail.tsx
+++ b/app/product/[id]/productDetail.tsx
@@ -1,6 +1,7 @@
 import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
 import ArrowRightIcon from '@/assets/icons/ic_arrow_right.svg';
 import HomeIcon from '@/assets/icons/ic_home.svg';
+import InfoIcon from '@/assets/icons/ic_info.svg';
 import SearchIcon from '@/assets/icons/ic_magnifier.svg';
 import StarIcon from '@/assets/icons/ic_star.svg';
 import EmptyReviewIcon from '@/assets/icons/product/productDetail/ic_no_review.svg';
@@ -10,8 +11,7 @@ import { ScrollToTopButton } from '@/components/common/buttons/ScrollToTopButton
 import DefaultModal from '@/components/common/modals/DefaultModal';
 import Navigation from '@/components/layout/Navigation';
 import BottomSheetLayout from '@/components/page/product/productDetail/BottomSeetLayout';
-// import CoupangTabBar from '@/components/page/product/productDetail/CoupangTabBar';
-import InfoIcon from '@/assets/icons/ic_info.svg';
+import CoupangTabBar from '@/components/page/product/productDetail/CoupangTabBar';
 import MaterialInfo from '@/components/page/product/productDetail/materialInfo';
 import PhotoCard from '@/components/page/product/productDetail/PhotoCard';
 import ReviewCard from '@/components/page/product/productDetail/ReviewCard';
@@ -107,7 +107,7 @@ export default function ProductDetail() {
     }, [qc, idNum, refetchRatingStats]),
   );
 
-  // const [coupangProduct, setCoupangProduct] = useState(null);
+  // const [coupangProduct, setCoupangProduct] = useState<ICoupang | null>(null);
 
   if (!data) return <Text>제품을 찾을 수 없습니다.</Text>;
 
@@ -115,7 +115,6 @@ export default function ProductDetail() {
     <PortalProvider>
       <SafeAreaView className='flex-1 bg-white'>
         <Stack.Screen options={{ headerShown: false }} />
-
         <Navigation
           left={
             <ArrowLeftIcon width={20} height={20} fill={colors.gray[900]} />
@@ -129,7 +128,6 @@ export default function ProductDetail() {
           }
           onRightPress={() => router.push('/home/search')}
         />
-
         <FlatList
           ref={listRef}
           onScroll={handleScroll}
@@ -453,8 +451,7 @@ export default function ProductDetail() {
             )
           }
         />
-
-        {/* <CoupangTabBar product={coupangProduct} /> */}
+        <CoupangTabBar id={id} coupangUrl='https://naver.com' /> // data.coupang
         <PortalHost name='overlay-top' />
         <DefaultModal
           visible={showIsMyReviewModal}

--- a/components/page/product/productDetail/CoupangTabBar.tsx
+++ b/components/page/product/productDetail/CoupangTabBar.tsx
@@ -1,5 +1,8 @@
+// TODO: 쿠팡 15만원 채우기 전까지 버튼 클릭 시 바로 링크로 이동, 이후 coupangPartnerScreen으로 이동
+
 import InfoIcon from '@/assets/icons/product/productDetail/ic_help.svg';
 import { LongButton } from '@/components/common/buttons/LongButton';
+import { getSafeUrl } from '@/utils/getSafeUrl';
 import { useEffect, useRef, useState } from 'react';
 import {
   Animated,
@@ -13,14 +16,17 @@ import {
 } from 'react-native';
 
 interface Props {
-  product: any;
+  id: string;
+  coupangUrl: string;
 }
 
-export default function CoopangTabBar({ product }: Props) {
-  //   if (!product) {
-  //     return null;
-  //   }
+export default function CoopangTabBar({ id, coupangUrl }: Props) {
+  const finalUrl = getSafeUrl(coupangUrl);
+  if (!id || !finalUrl) {
+    return;
+  }
 
+  // const router = useRouter();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const fadeAnim = useRef(new Animated.Value(0)).current;
 
@@ -40,10 +46,22 @@ export default function CoopangTabBar({ product }: Props) {
     }
   }, [isTooltipVisible, fadeAnim]);
 
-  const handlePress = () => {
-    Linking.openURL(product.productUrl).catch((err) =>
-      console.error('URL을 여는 데 실패했습니다.', err),
-    );
+  const handlePress = async () => {
+    if (!finalUrl) {
+      return;
+    }
+    const canOpen = await Linking.canOpenURL(finalUrl);
+    if (canOpen) {
+      await Linking.openURL(finalUrl);
+    }
+    // router.push({
+    //   pathname: '/product/[id]/coupangPartnerScreen',
+    //   params: {
+    //     id: String(id),
+    //     coupangUrl: coupang || '',
+    //     // imageUrl: cproduct.imageUrl || '',
+    //   },
+    // });
   };
 
   const toggleTooltip = () => {

--- a/services/product/coupang.ts
+++ b/services/product/coupang.ts
@@ -20,7 +20,7 @@ function generateAuthorization(path: string, requestBody: object) {
 
 export const searchCoupangProduct = async (keyword: string) => {
   if (!ACCESS_KEY || !SECRET_KEY) {
-    return null;
+    return { productUrl: null, price: null };
   }
 
   const requestBody = { keyword, limit: 1 };
@@ -38,16 +38,19 @@ export const searchCoupangProduct = async (keyword: string) => {
     const data = await response.json();
     if (data.rCode !== '0') {
       console.error('Coupang API Error:', data.rMessage);
-      return null;
+      return { productUrl: null, price: null };
     }
-    const product = data.data.productData[0];
-    if (!product) return null;
+    const product = data.data?.productData?.[0];
+    if (!product || !product.productUrl) {
+      console.warn('쿠팡에서 유효한 상품 URL을 찾을 수 없음');
+      return { productUrl: null, price: null };
+    }
     return {
       productUrl: product.productUrl,
-      price: product.salePrice,
+      price: product.salePrice ?? null,
     };
   } catch (error) {
     console.error('Failed to fetch Coupang product:', error);
-    return null;
+    return { productUrl: null, price: null };
   }
 };

--- a/services/product/getProductDetail.ts
+++ b/services/product/getProductDetail.ts
@@ -22,6 +22,7 @@ export type ProductDetailDTO = {
   unit: string; // "51g"
   piece: number; // 낱개 수량
   productType: string; // "supplement"
+  coupang: string;
   isMyReview: boolean;
   reviewCount: number; // int
   reviewAvg: number | null; // null 가능

--- a/types/models/coupang.ts
+++ b/types/models/coupang.ts
@@ -1,0 +1,6 @@
+export interface ICoupang {
+  id: number;
+  productUrl: string;
+  imageUrl: string;
+  price: number;
+}

--- a/utils/getSafeUrl.ts
+++ b/utils/getSafeUrl.ts
@@ -1,0 +1,11 @@
+export function getSafeUrl(link: string) {
+  // 절대 URL(http/https)이거나 상대 경로(/)로 시작하면 안전한 것으로 간주
+  const isAbsoluteUrl = /^https?:\/\//i.test(link);
+  const isRelativePath = link.startsWith('/');
+  const isHashLink = link.startsWith('#');
+  const isRelativeFile = link.startsWith('./') || link.startsWith('../');
+
+  const safeHref =
+    isAbsoluteUrl || isRelativePath || isHashLink || isRelativeFile ? link : '';
+  return safeHref;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- #101

## 📌 PR 내용
### `getSafeUrl.ts`
- 안전한 url인지 검사하는 유틸함수
- `CoupangTabBar`에서 props로 받은 url 검사 후, 안전한 url일 때 하단 버튼을 띄움

### `productDetail.tsx`
- `CoupangTabBar` props로 `id`, `data.coupang`(url) 넘김

### `CoupangTabBar.tsx`
- `id`, `coupangUrl` props로 받아옴
- `getSafeUrl`로 `coupangUrl` 안전성 검사
- `handlePress` 동작: 버튼 클릭하면 바로 `finalUrl`링크로 연결

### `getProductDetail.ts`
- `coupang: string;` 추가 


## 🗣️ 팀원에게 공유할 내용
- 아래 변경사항들은 추후 쿠팡 파트너스 연결 가능시 사용하기 위해 주석으로 남겨둡니다.

`CoupangTabBar.tsx`
- `handlePress`에 `coupangPartnerScreen` router 연결부 추가

`coupangPartnerScreen.tsx`
- 쿠팡 파트너스 연결 페이지
- `imageUrl`, `productUrl`을 props로 받아 제품 링크 연결 및 이미지 띄움

`types/models/coupang.ts`
- 쿠팡 타입 추가


