### PR TITLE
fix: 바텀시트 렌더링 구조 변경으로 안드로이드 터치 이슈 수정

### DIFF
--- a/app/auth/login/index.tsx
+++ b/app/auth/login/index.tsx
@@ -14,7 +14,6 @@ import BottomSheetLayout from '@/components/page/product/productDetail/BottomSee
 import { useAppleLogin } from '@/hooks/auth/useAppleLogin';
 import { useKakaoLogin } from '@/hooks/useKakaoLogin';
 import BottomSheet from '@gorhom/bottom-sheet';
-import { PortalProvider } from '@gorhom/portal';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Stack, useRouter } from 'expo-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -107,193 +106,191 @@ export default function Index({ emergency }: { emergency?: string }) {
   };
 
   return (
-    <PortalProvider>
-      <SafeAreaView className='flex-1 bg-white'>
-        <Stack.Screen options={{ headerShown: false }} />
-        {emergency && (
-          <Navigation right={<XIcon />} onRightPress={() => router.back()} />
-        )}
+    <SafeAreaView className='flex-1 bg-white'>
+      <Stack.Screen options={{ headerShown: false }} />
+      {emergency && (
+        <Navigation right={<XIcon />} onRightPress={() => router.back()} />
+      )}
 
-        <ScrollView
-          contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
-          className={scrollClassName}
-        >
-          <View className='flex-1 items-center'>
-            <View className='items-center w-full justify-center h-[64.98%]'>
-              <Logo width={112} height={33} />
-              <View className='flex-col items-center mt-[18px] '>
-                <Text className='text-b-sm font-n-rg text-gray-900'>
-                  다이어트 필수 정보,
-                </Text>
-                <Text className='text-b-sm font-n-rg text-gray-900'>
-                  보조제 성분부터 후기까지 한번에
-                </Text>
-              </View>
-            </View>
-
-            <View className=' w-full px-5 flex-col space-y-3'>
-              <KakaoLogin
-                onPress={() => {
-                  kakaoLogin.mutate(undefined, {
-                    onSuccess: (data) => {
-                      if (data.is_new_user) {
-                        openSheet();
-                      } else {
-                        router.replace('/home');
-                      }
-                    },
-                  });
-                }}
-              />
-              {isIOS && (
-                <LoginButton
-                  label='Apple로 로그인'
-                  onPress={() => {
-                    appleLogin();
-                  }}
-                  color='bg-[#000]'
-                  Icon={AppleIcon}
-                  textColor='text-white'
-                  border='border-none'
-                  IconWidth={16}
-                  IconHeight={20}
-                />
-              )}
-              <LoginButton
-                label='이메일로 로그인'
-                onPress={() => {
-                  router.push('/auth/login/email');
-                }}
-                color='bg-[#FFF]'
-                Icon={EmailIcon}
-                borderColor='border-gray-200'
-                textColor='text-black'
-                border='border'
-                IconWidth={18}
-                IconHeight={18}
-              />
-            </View>
-
-            {!emergency && (
-              <View className='flex-row items-center justify-center mt-[10px]'>
-                <Text className='text-b-sm font-n-rg text-gray-500'>
-                  서비스가 궁금하시다면?
-                </Text>
-
-                <Pressable
-                  onPress={() => {
-                    router.replace('/home');
-                  }}
-                >
-                  <Text className='text-b-md font-n-eb text-[#19B375] ml-1'>
-                    둘러보기
-                  </Text>
-                </Pressable>
-              </View>
-            )}
-          </View>
-        </ScrollView>
-
-        <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
-          {/* ===== 서비스 약관 동의 ===== */}
-          <View className='px-5 pt-[30px] pb-[45px]'>
-            <Pressable
-              onPress={toggleAll}
-              className='flex-row items-center mb-[28px] '
-              hitSlop={8}
-            >
-              {isAllChecked ? (
-                <CircleCheckGreenIcon className='mr-[11px]' />
-              ) : (
-                <CircleCheckGrayIcon className='mr-[11px]' />
-              )}
-
-              <Text className='text-b-md font-n-eb text-gray-700 items-center'>
-                서비스 이용 약관 동의(전체)
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
+        className={scrollClassName}
+      >
+        <View className='flex-1 items-center'>
+          <View className='items-center w-full justify-center h-[64.98%]'>
+            <Logo width={112} height={33} />
+            <View className='flex-col items-center mt-[18px] '>
+              <Text className='text-b-sm font-n-rg text-gray-900'>
+                다이어트 필수 정보,
               </Text>
-            </Pressable>
-
-            <View className='gap-y-[25px] mb-[25px]'>
-              {TERMS.map(({ id, terms, essential }, idx) => {
-                const checked = checkedSet.has(idx);
-                return (
-                  <View
-                    key={idx}
-                    className='flex-row items-center justify-between'
-                  >
-                    <Pressable
-                      onPress={() => toggleItem(idx)}
-                      className='flex-row items-center '
-                      hitSlop={8}
-                    >
-                      <Svg
-                        width={18}
-                        height={18}
-                        viewBox='0 0 18 18'
-                        fill='none'
-                        className='mr-[13px]'
-                      >
-                        <Path
-                          d='M16.5 4.5L6.5 15L1.5 9'
-                          stroke={checked ? '#50D88F' : '#C9CDD2'}
-                          strokeWidth={1.5}
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                        />
-                      </Svg>
-                      {essential ? (
-                        <Text
-                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                        >
-                          [필수]
-                        </Text>
-                      ) : (
-                        <Text
-                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                        >
-                          [선택]
-                        </Text>
-                      )}
-                      <Text
-                        className={`ml-[2px] font-n-bd text-b-sm ${
-                          !checked && 'text-b-sm text-gray-400'
-                        }`}
-                      >
-                        {terms}
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => {
-                        setIsTermsModalVisible(true);
-                        setSelectedTerm(id);
-                      }}
-                    >
-                      <RightArrowIcon />
-                    </Pressable>
-                  </View>
-                );
-              })}
+              <Text className='text-b-sm font-n-rg text-gray-900'>
+                보조제 성분부터 후기까지 한번에
+              </Text>
             </View>
-            <LongButton
-              label='동의하고 계속하기'
-              onPress={onPressSubmit}
-              disabled={!isEssentialChecked}
+          </View>
+
+          <View className=' w-full px-5 flex-col space-y-3'>
+            <KakaoLogin
+              onPress={() => {
+                kakaoLogin.mutate(undefined, {
+                  onSuccess: (data) => {
+                    if (data.is_new_user) {
+                      openSheet();
+                    } else {
+                      router.replace('/home');
+                    }
+                  },
+                });
+              }}
+            />
+            {isIOS && (
+              <LoginButton
+                label='Apple로 로그인'
+                onPress={() => {
+                  appleLogin();
+                }}
+                color='bg-[#000]'
+                Icon={AppleIcon}
+                textColor='text-white'
+                border='border-none'
+                IconWidth={16}
+                IconHeight={20}
+              />
+            )}
+            <LoginButton
+              label='이메일로 로그인'
+              onPress={() => {
+                router.push('/auth/login/email');
+              }}
+              color='bg-[#FFF]'
+              Icon={EmailIcon}
+              borderColor='border-gray-200'
+              textColor='text-black'
+              border='border'
+              IconWidth={18}
+              IconHeight={18}
             />
           </View>
-        </BottomSheetLayout>
-        <HomeFooterModal
-          type={
-            selectedTerm as
-              | 'service'
-              | 'privacy'
-              | 'age'
-              | 'appUsage'
-              | 'notification'
-          }
-          visible={isTermsModalVisible}
-          onClose={() => setIsTermsModalVisible(false)}
-        />
-      </SafeAreaView>
-    </PortalProvider>
+
+          {!emergency && (
+            <View className='flex-row items-center justify-center mt-[10px]'>
+              <Text className='text-b-sm font-n-rg text-gray-500'>
+                서비스가 궁금하시다면?
+              </Text>
+
+              <Pressable
+                onPress={() => {
+                  router.replace('/home');
+                }}
+              >
+                <Text className='text-b-md font-n-eb text-[#19B375] ml-1'>
+                  둘러보기
+                </Text>
+              </Pressable>
+            </View>
+          )}
+        </View>
+      </ScrollView>
+
+      <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
+        {/* ===== 서비스 약관 동의 ===== */}
+        <View className='px-5 pt-[30px] pb-[45px]'>
+          <Pressable
+            onPress={toggleAll}
+            className='flex-row items-center mb-[28px] '
+            hitSlop={8}
+          >
+            {isAllChecked ? (
+              <CircleCheckGreenIcon className='mr-[11px]' />
+            ) : (
+              <CircleCheckGrayIcon className='mr-[11px]' />
+            )}
+
+            <Text className='text-b-md font-n-eb text-gray-700 items-center'>
+              서비스 이용 약관 동의(전체)
+            </Text>
+          </Pressable>
+
+          <View className='gap-y-[25px] mb-[25px]'>
+            {TERMS.map(({ id, terms, essential }, idx) => {
+              const checked = checkedSet.has(idx);
+              return (
+                <View
+                  key={idx}
+                  className='flex-row items-center justify-between'
+                >
+                  <Pressable
+                    onPress={() => toggleItem(idx)}
+                    className='flex-row items-center '
+                    hitSlop={8}
+                  >
+                    <Svg
+                      width={18}
+                      height={18}
+                      viewBox='0 0 18 18'
+                      fill='none'
+                      className='mr-[13px]'
+                    >
+                      <Path
+                        d='M16.5 4.5L6.5 15L1.5 9'
+                        stroke={checked ? '#50D88F' : '#C9CDD2'}
+                        strokeWidth={1.5}
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                      />
+                    </Svg>
+                    {essential ? (
+                      <Text
+                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                      >
+                        [필수]
+                      </Text>
+                    ) : (
+                      <Text
+                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                      >
+                        [선택]
+                      </Text>
+                    )}
+                    <Text
+                      className={`ml-[2px] font-n-bd text-b-sm ${
+                        !checked && 'text-b-sm text-gray-400'
+                      }`}
+                    >
+                      {terms}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      setIsTermsModalVisible(true);
+                      setSelectedTerm(id);
+                    }}
+                  >
+                    <RightArrowIcon />
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
+          <LongButton
+            label='동의하고 계속하기'
+            onPress={onPressSubmit}
+            disabled={!isEssentialChecked}
+          />
+        </View>
+      </BottomSheetLayout>
+      <HomeFooterModal
+        type={
+          selectedTerm as
+            | 'service'
+            | 'privacy'
+            | 'age'
+            | 'appUsage'
+            | 'notification'
+        }
+        visible={isTermsModalVisible}
+        onClose={() => setIsTermsModalVisible(false)}
+      />
+    </SafeAreaView>
   );
 }

--- a/app/auth/signUp/index.tsx
+++ b/app/auth/signUp/index.tsx
@@ -17,7 +17,6 @@ import {
   isSamePassword,
 } from '@/utils/validation';
 import BottomSheet from '@gorhom/bottom-sheet';
-import { PortalProvider } from '@gorhom/portal';
 import { Stack, useRouter } from 'expo-router';
 import { useMemo, useRef, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
@@ -136,158 +135,156 @@ export default function Index() {
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
-      <PortalProvider>
-        <Navigation
-          left={<ArrowLeftIcon width={20} height={20} />}
-          onLeftPress={() => router.back()}
-        />
+      <Navigation
+        left={<ArrowLeftIcon width={20} height={20} />}
+        onLeftPress={() => router.back()}
+      />
 
-        <View className='p-5'>
-          <Text className='text-h-lg font-n-eb text-gray-700 mb-[12px]'>
-            회원가입
-          </Text>
-          <Text className='text-b-md font-n-bd text-gray-700 mb-[8px]'>
-            계정 생성 후,
-          </Text>
-          <Text className='text-b-md font-n-bd text-gray-700 mb-[25px]'>
-            휴대폰 본인인증을 완료하면 가입이 완료됩니다.
-          </Text>
+      <View className='p-5'>
+        <Text className='text-h-lg font-n-eb text-gray-700 mb-[12px]'>
+          회원가입
+        </Text>
+        <Text className='text-b-md font-n-bd text-gray-700 mb-[8px]'>
+          계정 생성 후,
+        </Text>
+        <Text className='text-b-md font-n-bd text-gray-700 mb-[25px]'>
+          휴대폰 본인인증을 완료하면 가입이 완료됩니다.
+        </Text>
 
-          <View className='space-y-[18px] mb-[25px]'>
-            <View>
-              <TextField
-                menu={1}
-                value={email}
-                onChangeText={handleChangeEmail}
-                // onEndEditing={handleEmailEndEditing}
-                placeholder='이메일을 입력해주세요.'
-                firstMessage={
-                  isExistsEmail ? '이미 가입된 이메일입니다.' : '이메일 형식'
-                }
-                validateFirst={(v) => isEmail(v) && !isExistsEmail}
-              />
-            </View>
-            <View>
-              <TextField
-                menu={1}
-                value={password}
-                onChangeText={setPassword}
-                placeholder='비밀번호를 입력해주세요.'
-                firstMessage='8-20자 이내'
-                secondMessage='영문, 숫자, 특수문자 포함'
-                validateFirst={isLen8to20}
-                validateSecond={hasPasswordComposition}
-                secureTextEntry={true}
-              />
-            </View>
-            <View>
-              <TextField
-                menu={1}
-                value={confirmPassword}
-                onChangeText={setConfirmPassword}
-                placeholder='비밀번호를 다시 입력해주세요.'
-                firstMessage='비밀번호 일치'
-                validateFirst={(t) => isSamePassword(password, t)}
-                secureTextEntry={true}
-              />
-            </View>
-          </View>
-
-          <LongButton
-            label={isPending ? '확인 중...' : '휴대폰 본인인증'}
-            onPress={onPressPhoneAuth}
-            disabled={!canSubmit || isPending}
-          />
-        </View>
-
-        <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
-          {/* ===== 서비스 약관 동의 ===== */}
-          <View className='px-5 pt-[30px] pb-[45px]'>
-            <Pressable
-              onPress={toggleAll}
-              className='flex-row items-center mb-[28px] '
-              hitSlop={8}
-            >
-              {isAllChecked ? (
-                <CircleCheckGreenIcon className='mr-[11px]' />
-              ) : (
-                <CircleCheckGrayIcon className='mr-[11px]' />
-              )}
-
-              <Text className='text-b-md font-n-eb text-gray-700 items-center'>
-                서비스 이용 약관 동의(전체)
-              </Text>
-            </Pressable>
-
-            <View className='gap-y-[25px] mb-[25px]'>
-              {TERMS.map(({ id, terms, essential }, idx) => {
-                const checked = checkedSet.has(idx);
-                return (
-                  <View
-                    key={idx}
-                    className='flex-row items-center justify-between'
-                  >
-                    <Pressable
-                      onPress={() => toggleItem(idx)}
-                      className='flex-row items-center '
-                      hitSlop={8}
-                    >
-                      <Svg
-                        width={18}
-                        height={18}
-                        viewBox='0 0 18 18'
-                        fill='none'
-                        className='mr-[13px]'
-                      >
-                        <Path
-                          d='M16.5 4.5L6.5 15L1.5 9'
-                          stroke={checked ? '#50D88F' : '#C9CDD2'}
-                          strokeWidth={1.5}
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                        />
-                      </Svg>
-                      {essential ? (
-                        <Text
-                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                        >
-                          [필수]
-                        </Text>
-                      ) : (
-                        <Text
-                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                        >
-                          [선택]
-                        </Text>
-                      )}
-                      <Text
-                        className={`ml-[2px] font-n-bd text-b-sm ${
-                          !checked && 'text-b-sm text-gray-400'
-                        }`}
-                      >
-                        {terms}
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => {
-                        setIsTermsModalVisible(true);
-                        setSelectedTerm(id);
-                      }}
-                    >
-                      <RightArrowIcon />
-                    </Pressable>
-                  </View>
-                );
-              })}
-            </View>
-            <LongButton
-              label='동의하고 계속하기'
-              onPress={onPressSubmit}
-              disabled={!isEssentialChecked}
+        <View className='space-y-[18px] mb-[25px]'>
+          <View>
+            <TextField
+              menu={1}
+              value={email}
+              onChangeText={handleChangeEmail}
+              // onEndEditing={handleEmailEndEditing}
+              placeholder='이메일을 입력해주세요.'
+              firstMessage={
+                isExistsEmail ? '이미 가입된 이메일입니다.' : '이메일 형식'
+              }
+              validateFirst={(v) => isEmail(v) && !isExistsEmail}
             />
           </View>
-        </BottomSheetLayout>
-      </PortalProvider>
+          <View>
+            <TextField
+              menu={1}
+              value={password}
+              onChangeText={setPassword}
+              placeholder='비밀번호를 입력해주세요.'
+              firstMessage='8-20자 이내'
+              secondMessage='영문, 숫자, 특수문자 포함'
+              validateFirst={isLen8to20}
+              validateSecond={hasPasswordComposition}
+              secureTextEntry={true}
+            />
+          </View>
+          <View>
+            <TextField
+              menu={1}
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+              placeholder='비밀번호를 다시 입력해주세요.'
+              firstMessage='비밀번호 일치'
+              validateFirst={(t) => isSamePassword(password, t)}
+              secureTextEntry={true}
+            />
+          </View>
+        </View>
+
+        <LongButton
+          label={isPending ? '확인 중...' : '휴대폰 본인인증'}
+          onPress={onPressPhoneAuth}
+          disabled={!canSubmit || isPending}
+        />
+      </View>
+
+      <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
+        {/* ===== 서비스 약관 동의 ===== */}
+        <View className='px-5 pt-[30px] pb-[45px]'>
+          <Pressable
+            onPress={toggleAll}
+            className='flex-row items-center mb-[28px] '
+            hitSlop={8}
+          >
+            {isAllChecked ? (
+              <CircleCheckGreenIcon className='mr-[11px]' />
+            ) : (
+              <CircleCheckGrayIcon className='mr-[11px]' />
+            )}
+
+            <Text className='text-b-md font-n-eb text-gray-700 items-center'>
+              서비스 이용 약관 동의(전체)
+            </Text>
+          </Pressable>
+
+          <View className='gap-y-[25px] mb-[25px]'>
+            {TERMS.map(({ id, terms, essential }, idx) => {
+              const checked = checkedSet.has(idx);
+              return (
+                <View
+                  key={idx}
+                  className='flex-row items-center justify-between'
+                >
+                  <Pressable
+                    onPress={() => toggleItem(idx)}
+                    className='flex-row items-center '
+                    hitSlop={8}
+                  >
+                    <Svg
+                      width={18}
+                      height={18}
+                      viewBox='0 0 18 18'
+                      fill='none'
+                      className='mr-[13px]'
+                    >
+                      <Path
+                        d='M16.5 4.5L6.5 15L1.5 9'
+                        stroke={checked ? '#50D88F' : '#C9CDD2'}
+                        strokeWidth={1.5}
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                      />
+                    </Svg>
+                    {essential ? (
+                      <Text
+                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                      >
+                        [필수]
+                      </Text>
+                    ) : (
+                      <Text
+                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                      >
+                        [선택]
+                      </Text>
+                    )}
+                    <Text
+                      className={`ml-[2px] font-n-bd text-b-sm ${
+                        !checked && 'text-b-sm text-gray-400'
+                      }`}
+                    >
+                      {terms}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      setIsTermsModalVisible(true);
+                      setSelectedTerm(id);
+                    }}
+                  >
+                    <RightArrowIcon />
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
+          <LongButton
+            label='동의하고 계속하기'
+            onPress={onPressSubmit}
+            disabled={!isEssentialChecked}
+          />
+        </View>
+      </BottomSheetLayout>
 
       <HomeFooterModal
         type={

--- a/app/product/[id]/productDetail.tsx
+++ b/app/product/[id]/productDetail.tsx
@@ -26,7 +26,7 @@ import { useProductRatingStats } from '@/hooks/product/review/useProductRatingSt
 import { useProductDetail } from '@/hooks/product/useProductDetail';
 import { useUser } from '@/hooks/useUser';
 import BottomSheet from '@gorhom/bottom-sheet';
-import { PortalHost, PortalProvider } from '@gorhom/portal';
+import { PortalHost } from '@gorhom/portal';
 
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -112,354 +112,337 @@ export default function ProductDetail() {
   if (!data) return <Text>제품을 찾을 수 없습니다.</Text>;
 
   return (
-    <PortalProvider>
-      <SafeAreaView className='flex-1 bg-white'>
-        <Stack.Screen options={{ headerShown: false }} />
-        <Navigation
-          left={
-            <ArrowLeftIcon width={20} height={20} fill={colors.gray[900]} />
-          }
-          onLeftPress={() => router.back()}
-          right={<SearchIcon width={20} height={20} fill={colors.gray[900]} />}
-          secondRight={
-            <Pressable onPress={() => router.push('/home')}>
-              <HomeIcon width={20} height={20} fill={colors.gray[900]} />
-            </Pressable>
-          }
-          onRightPress={() => router.push('/home/search')}
-        />
-        <FlatList
-          ref={listRef}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          data={listData}
-          keyExtractor={(_, index) => String(index)}
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 24 }}
-          /* 상단 고정 영역 */
-          ListHeaderComponent={
-            <View>
-              {/* 상품 이미지 */}
-              <View className='h-[46.2vh] w-full'>
-                {(() => {
-                  const img = data?.images;
-                  let imageSource: { uri: string } | undefined;
+    <SafeAreaView className='flex-1 bg-white'>
+      <Stack.Screen options={{ headerShown: false }} />
+      <Navigation
+        left={<ArrowLeftIcon width={20} height={20} fill={colors.gray[900]} />}
+        onLeftPress={() => router.back()}
+        right={<SearchIcon width={20} height={20} fill={colors.gray[900]} />}
+        secondRight={
+          <Pressable onPress={() => router.push('/home')}>
+            <HomeIcon width={20} height={20} fill={colors.gray[900]} />
+          </Pressable>
+        }
+        onRightPress={() => router.push('/home/search')}
+      />
+      <FlatList
+        ref={listRef}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        data={listData}
+        keyExtractor={(_, index) => String(index)}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 24 }}
+        /* 상단 고정 영역 */
+        ListHeaderComponent={
+          <View>
+            {/* 상품 이미지 */}
+            <View className='h-[46.2vh] w-full'>
+              {(() => {
+                const img = data?.images;
+                let imageSource: { uri: string } | undefined;
 
-                  if (Array.isArray(img) && img.length > 0) {
-                    const first = img[0];
-                    if (typeof first === 'string') {
-                      imageSource = { uri: first };
-                    } else if (
-                      first &&
-                      typeof first === 'object' &&
-                      typeof first.url === 'string'
-                    ) {
-                      imageSource = { uri: first.url };
-                    }
+                if (Array.isArray(img) && img.length > 0) {
+                  const first = img[0];
+                  if (typeof first === 'string') {
+                    imageSource = { uri: first };
+                  } else if (
+                    first &&
+                    typeof first === 'object' &&
+                    typeof first.url === 'string'
+                  ) {
+                    imageSource = { uri: first.url };
                   }
-                  return imageSource ? (
-                    <Image
-                      source={imageSource}
-                      style={{ width: '100%', height: '100%' }}
-                      resizeMode='contain'
+                }
+                return imageSource ? (
+                  <Image
+                    source={imageSource}
+                    style={{ width: '100%', height: '100%' }}
+                    resizeMode='contain'
+                  />
+                ) : (
+                  <View className='border-gray-100 border w-full h-full items-center justify-center'>
+                    <Text className='text-b-lg font-n-bd text-gray-500'>
+                      상품 이미지를 준비중입니다.
+                    </Text>
+                  </View>
+                );
+              })()}
+            </View>
+
+            {/* 상품 정보 헤더 */}
+            <View className='flex-col border-gray-100 border-b py-[20px]'>
+              <View className='flex-col px-[20px] '>
+                <Text className='text-b-sm font-n-bd  mb-[15px]'>
+                  {data?.company}
+                </Text>
+                <Text className='text-h-md font-n-bd  mb-[15px]'>
+                  {data?.name}
+                </Text>
+                <View className='flex-row items-center '>
+                  <StarIcon />
+                  <Text className='text-c1 font-n-rg text-gray-400 ml-[3px]'>
+                    {data?.reviewAvg ?? 0} ({data?.reviewCount ?? 0})
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            {/* 랭킹 및 영양 정보 */}
+            <View className='flex-col gap-y-4 border-gray-100 border-b-[3px] py-5 px-5 '>
+              <View className='flex-row w-full'>
+                <View className='flex-[0.2]'>
+                  <Text className='text-c2 font-n-rg text-gray-400'>랭킹</Text>
+                </View>
+
+                <View className='flex-col flex-wrap flex-[0.8]'>
+                  {data?.ranking?.map((item, index) => (
+                    <View key={index} className='flex-row items-baseline mr-2'>
+                      <Text className='text-c2 font-n-rg h-[16px]'>
+                        {item.bigCategory}
+                      </Text>
+                      <Text className='text-c2 font-n-rg'> / </Text>
+                      <Text className='text-c2 font-n-rg'>
+                        {item.smallCategory} {item.monthlyRank}위
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+              <View className='flex-row w-full'>
+                <View className='flex-[0.2]'>
+                  <Text className='text-c2 font-n-rg text-gray-400'>
+                    식품 유형
+                  </Text>
+                </View>
+
+                <View className='flex-[0.8]'>
+                  <Text className='text-c2 font-n-rg'>{data?.productType}</Text>
+                </View>
+              </View>
+            </View>
+
+            {/* 탭 */}
+            <CustomTabs
+              tabs={tabs}
+              value={activeTab}
+              onChange={(key) => setActiveTab(key as 'ingredient' | 'review')}
+            />
+
+            {/* 탭별 상단 콘텐츠 */}
+            {activeTab === 'ingredient' ? (
+              <IngredientSection product={data} openSheet={openSheet} />
+            ) : (
+              <View className='px-5 mt-5'>
+                <View className='flex-row items-center justify-between mb-5'>
+                  <View className='flex-row items-center'>
+                    <Text className='text-b-lg font-n-bd'>리뷰 </Text>
+                    <Text className='text-b-lg font-n-bd text-gray-400'>
+                      ({ratingStats?.total_reviews ?? 0})
+                    </Text>
+                  </View>
+                  {(ratingStats?.total_reviews ?? 0) > 0 && (
+                    <Pressable
+                      onPress={async () => {
+                        if (await isLoggedIn()) {
+                          qc.setQueryData(
+                            ['product', 'ratingStats', Number(id)],
+                            ratingStats,
+                          );
+                          qc.setQueryData(['product', 'photo-preview', idNum], {
+                            previewPhotos: previewPhotoUrls ?? [],
+                            total_photo:
+                              reviewImageList?.pages?.[0]?.total_images ?? 0,
+                          });
+                          qc.setQueryData(['product', 'detail', idNum], {
+                            reviewAvg: data?.reviewAvg,
+                            reviewCount: data?.reviewCount,
+                          });
+                          router.push(`/product/${id}/review/allReview`);
+                        } else {
+                          router.push('/auth/login/emergency');
+                        }
+                      }}
+                    >
+                      <ArrowRightIcon />
+                    </Pressable>
+                  )}
+                </View>
+
+                <LongButton
+                  label={'리뷰 작성하기'}
+                  height={'h-[44px]'}
+                  onPress={async () => {
+                    if (data?.isMyReview) {
+                      setShowIsMyReviewModal(true);
+                      return;
+                    } else {
+                      if (await isLoggedIn()) {
+                        router.push({
+                          pathname: `/product/${id}/review/write` as any,
+                          params: {
+                            id: String(id), // 제품아이디
+                            name: data?.name ?? '', // 제품명
+                            brand: data?.company ?? '', // 회사명
+                            image: data?.images[0]?.url ?? '',
+                          },
+                        });
+                      } else {
+                        router.push('/auth/login/emergency');
+                      }
+                    }
+                  }}
+                />
+
+                {(ratingStats?.total_reviews ?? 0) <= 0 ? (
+                  <View className='items-center mt-[60px]'>
+                    <EmptyReviewIcon />
+                    <View className='flex-col items-center mt-[15px]'>
+                      <Text className='text-b-md font-n-bd text-gray-600 mb-[7px]'>
+                        아직 작성된 리뷰가 없어요.
+                      </Text>
+                      <Text className='text-b-md font-n-bd text-gray-600'>
+                        첫번째 리뷰를 작성해주세요!
+                      </Text>
+                    </View>
+                  </View>
+                ) : (
+                  <View className='mt-[16px]'>
+                    <ReviewCard
+                      reviewRank={data?.reviewAvg || 0}
+                      distribution={{
+                        5: ratingStats?.percentages[5] || 0,
+                        4: ratingStats?.percentages[4] || 0,
+                        3: ratingStats?.percentages[3] || 0,
+                        2: ratingStats?.percentages[2] || 0,
+                        1: ratingStats?.percentages[1] || 0,
+                      }}
                     />
-                  ) : (
-                    <View className='border-gray-100 border w-full h-full items-center justify-center'>
-                      <Text className='text-b-lg font-n-bd text-gray-500'>
-                        상품 이미지를 준비중입니다.
-                      </Text>
-                    </View>
-                  );
-                })()}
-              </View>
 
-              {/* 상품 정보 헤더 */}
-              <View className='flex-col border-gray-100 border-b py-[20px]'>
-                <View className='flex-col px-[20px] '>
-                  <Text className='text-b-sm font-n-bd  mb-[15px]'>
-                    {data?.company}
-                  </Text>
-                  <Text className='text-h-md font-n-bd  mb-[15px]'>
-                    {data?.name}
-                  </Text>
-                  <View className='flex-row items-center '>
-                    <StarIcon />
-                    <Text className='text-c1 font-n-rg text-gray-400 ml-[3px]'>
-                      {data?.reviewAvg ?? 0} ({data?.reviewCount ?? 0})
-                    </Text>
-                  </View>
-                </View>
-              </View>
-
-              {/* 랭킹 및 영양 정보 */}
-              <View className='flex-col gap-y-4 border-gray-100 border-b-[3px] py-5 px-5 '>
-                <View className='flex-row w-full'>
-                  <View className='flex-[0.2]'>
-                    <Text className='text-c2 font-n-rg text-gray-400'>
-                      랭킹
-                    </Text>
-                  </View>
-
-                  <View className='flex-col flex-wrap flex-[0.8]'>
-                    {data?.ranking?.map((item, index) => (
-                      <View
-                        key={index}
-                        className='flex-row items-baseline mr-2'
-                      >
-                        <Text className='text-c2 font-n-rg h-[16px]'>
-                          {item.bigCategory}
-                        </Text>
-                        <Text className='text-c2 font-n-rg'> / </Text>
-                        <Text className='text-c2 font-n-rg'>
-                          {item.smallCategory} {item.monthlyRank}위
-                        </Text>
-                      </View>
-                    ))}
-                  </View>
-                </View>
-                <View className='flex-row w-full'>
-                  <View className='flex-[0.2]'>
-                    <Text className='text-c2 font-n-rg text-gray-400'>
-                      식품 유형
-                    </Text>
-                  </View>
-
-                  <View className='flex-[0.8]'>
-                    <Text className='text-c2 font-n-rg'>
-                      {data?.productType}
-                    </Text>
-                  </View>
-                </View>
-              </View>
-
-              {/* 탭 */}
-              <CustomTabs
-                tabs={tabs}
-                value={activeTab}
-                onChange={(key) => setActiveTab(key as 'ingredient' | 'review')}
-              />
-
-              {/* 탭별 상단 콘텐츠 */}
-              {activeTab === 'ingredient' ? (
-                <IngredientSection product={data} openSheet={openSheet} />
-              ) : (
-                <View className='px-5 mt-5'>
-                  <View className='flex-row items-center justify-between mb-5'>
-                    <View className='flex-row items-center'>
-                      <Text className='text-b-lg font-n-bd'>리뷰 </Text>
-                      <Text className='text-b-lg font-n-bd text-gray-400'>
-                        ({ratingStats?.total_reviews ?? 0})
-                      </Text>
-                    </View>
-                    {(ratingStats?.total_reviews ?? 0) > 0 && (
-                      <Pressable
-                        onPress={async () => {
+                    {/* 사진 그리드(주의: 내부가 세로 FlatList면 View+map 버전으로 바꾸기) */}
+                    <View className='mt-4 pb-5'>
+                      <PhotoCard
+                        images={previewPhotoUrls ?? []}
+                        maxPreview={6}
+                        onPressPhoto={async (idx) => {
                           if (await isLoggedIn()) {
-                            qc.setQueryData(
-                              ['product', 'ratingStats', Number(id)],
-                              ratingStats,
-                            );
-                            qc.setQueryData(
-                              ['product', 'photo-preview', idNum],
-                              {
-                                previewPhotos: previewPhotoUrls ?? [],
-                                total_photo:
-                                  reviewImageList?.pages?.[0]?.total_images ??
-                                  0,
-                              },
-                            );
+                            const imageUrl = previewPhotoUrls?.[idx];
+                            if (!imageUrl) return;
                             qc.setQueryData(['product', 'detail', idNum], {
                               reviewAvg: data?.reviewAvg,
                               reviewCount: data?.reviewCount,
                             });
-                            router.push(`/product/${id}/review/allReview`);
+                            router.push({
+                              pathname:
+                                '/product/[id]/review/[reviewId]/photoReviewDetail',
+                              params: {
+                                id: String(id),
+                                reviewId: String(parseReviewId(imageUrl)),
+                                imageUrl,
+                                index: idx,
+                              },
+                            });
                           } else {
                             router.push('/auth/login/emergency');
                           }
                         }}
-                      >
-                        <ArrowRightIcon />
-                      </Pressable>
-                    )}
-                  </View>
-
-                  <LongButton
-                    label={'리뷰 작성하기'}
-                    height={'h-[44px]'}
-                    onPress={async () => {
-                      if (data?.isMyReview) {
-                        setShowIsMyReviewModal(true);
-                        return;
-                      } else {
-                        if (await isLoggedIn()) {
-                          router.push({
-                            pathname: `/product/${id}/review/write` as any,
-                            params: {
-                              id: String(id), // 제품아이디
-                              name: data?.name ?? '', // 제품명
-                              brand: data?.company ?? '', // 회사명
-                              image: data?.images[0]?.url ?? '',
-                            },
+                        onPressMore={async () => {
+                          qc.setQueryData(['product', 'detail', idNum], {
+                            reviewAvg: data?.reviewAvg,
+                            reviewCount: data?.reviewCount,
                           });
-                        } else {
-                          router.push('/auth/login/emergency');
-                        }
-                      }
-                    }}
-                  />
-
-                  {(ratingStats?.total_reviews ?? 0) <= 0 ? (
-                    <View className='items-center mt-[60px]'>
-                      <EmptyReviewIcon />
-                      <View className='flex-col items-center mt-[15px]'>
-                        <Text className='text-b-md font-n-bd text-gray-600 mb-[7px]'>
-                          아직 작성된 리뷰가 없어요.
-                        </Text>
-                        <Text className='text-b-md font-n-bd text-gray-600'>
-                          첫번째 리뷰를 작성해주세요!
-                        </Text>
-                      </View>
-                    </View>
-                  ) : (
-                    <View className='mt-[16px]'>
-                      <ReviewCard
-                        reviewRank={data?.reviewAvg || 0}
-                        distribution={{
-                          5: ratingStats?.percentages[5] || 0,
-                          4: ratingStats?.percentages[4] || 0,
-                          3: ratingStats?.percentages[3] || 0,
-                          2: ratingStats?.percentages[2] || 0,
-                          1: ratingStats?.percentages[1] || 0,
-                        }}
-                      />
-
-                      {/* 사진 그리드(주의: 내부가 세로 FlatList면 View+map 버전으로 바꾸기) */}
-                      <View className='mt-4 pb-5'>
-                        <PhotoCard
-                          images={previewPhotoUrls ?? []}
-                          maxPreview={6}
-                          onPressPhoto={async (idx) => {
-                            if (await isLoggedIn()) {
-                              const imageUrl = previewPhotoUrls?.[idx];
-                              if (!imageUrl) return;
-                              qc.setQueryData(['product', 'detail', idNum], {
-                                reviewAvg: data?.reviewAvg,
-                                reviewCount: data?.reviewCount,
-                              });
-                              router.push({
-                                pathname:
-                                  '/product/[id]/review/[reviewId]/photoReviewDetail',
-                                params: {
-                                  id: String(id),
-                                  reviewId: String(parseReviewId(imageUrl)),
-                                  imageUrl,
-                                  index: idx,
-                                },
-                              });
-                            } else {
-                              router.push('/auth/login/emergency');
-                            }
-                          }}
-                          onPressMore={async () => {
-                            qc.setQueryData(['product', 'detail', idNum], {
-                              reviewAvg: data?.reviewAvg,
-                              reviewCount: data?.reviewCount,
-                            });
-                            if (await isLoggedIn()) {
-                              router.push(
-                                `/product/${id}/review/photo/allList`,
-                              );
-                            } else {
-                              router.push('/auth/login/emergency');
-                            }
-                          }}
-                          total_photo={
-                            reviewImageList?.pages[0]?.total_images ?? 0
+                          if (await isLoggedIn()) {
+                            router.push(`/product/${id}/review/photo/allList`);
+                          } else {
+                            router.push('/auth/login/emergency');
                           }
-                        />
-                      </View>
-
-                      {/* 아래부터는 아이템을 renderItem으로 렌더 */}
-                      <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
+                        }}
+                        total_photo={
+                          reviewImageList?.pages[0]?.total_images ?? 0
+                        }
+                      />
                     </View>
-                  )}
-                </View>
-              )}
-            </View>
-          }
-          /* 리뷰 탭일 때만 아이템(리뷰) 렌더 */
-          renderItem={
-            activeTab === 'review'
-              ? ({ item, index }) => (
-                  <View key={index}>
-                    <ReviewItems
-                      reviewItem={{
-                        id: item.review_id ?? '',
-                        reviewId: item.review_id ?? '',
-                        name: item.user_nickname ?? '',
-                        date: item.date ?? '-',
-                        isEdited: item.updated,
-                        content: item.review ?? '',
-                        rating: item.rate ?? 0,
-                        images: item.images ?? [],
-                      }}
-                      id={id}
-                      enableBottomSheet={
-                        !mypageInfo?.nickname === item.user_nickname
-                      }
-                    />
+
+                    {/* 아래부터는 아이템을 renderItem으로 렌더 */}
                     <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
                   </View>
-                )
-              : undefined
-          }
-          ListFooterComponent={
-            activeTab === 'review' && (ratingStats?.total_reviews ?? 0) > 0 ? (
-              <View className='items-center mt-4 mb-6'>
-                <ReviewButton
-                  onPress={() => {
-                    qc.setQueryData(
-                      ['product', 'ratingStats', Number(id)],
-                      ratingStats,
-                    );
-                    qc.setQueryData(['product', 'photo-preview', idNum], {
-                      previewPhotos: previewPhotoUrls ?? [],
-                      total_photo: reviewImageList?.pages[0]?.total_images ?? 0,
-                    });
-                    qc.setQueryData(['product', 'detail', idNum], {
-                      reviewAvg: data?.reviewAvg,
-                      reviewCount: data?.reviewCount,
-                    });
-                    router.push(`/product/${id}/review/allReview`);
-                  }}
-                  count={ratingStats?.total_reviews ?? 0}
-                />
+                )}
               </View>
-            ) : (
-              <View style={{ height: 24 }} />
-            )
-          }
-        />
-        {/* data.coupang */}
-        <CoupangTabBar id={id} coupangUrl='https://naver.com' />
-        <PortalHost name='overlay-top' />
-        <DefaultModal
-          visible={showIsMyReviewModal}
-          message='이미 리뷰를 작성하셨어요.'
-          confirmText='확인'
-          onConfirm={() => setShowIsMyReviewModal(false)}
-          singleButton={true}
-        />
-        <ScrollToTopButton
-          scrollRef={{
-            current: {
-              scrollTo: ({ y, animated }: any) =>
-                listRef.current?.scrollToOffset({ offset: y, animated }),
-            },
-          }}
-          visible={showTopButton}
-        />
-      </SafeAreaView>
+            )}
+          </View>
+        }
+        /* 리뷰 탭일 때만 아이템(리뷰) 렌더 */
+        renderItem={
+          activeTab === 'review'
+            ? ({ item, index }) => (
+                <View key={index}>
+                  <ReviewItems
+                    reviewItem={{
+                      id: item.review_id ?? '',
+                      reviewId: item.review_id ?? '',
+                      name: item.user_nickname ?? '',
+                      date: item.date ?? '-',
+                      isEdited: item.updated,
+                      content: item.review ?? '',
+                      rating: item.rate ?? 0,
+                      images: item.images ?? [],
+                    }}
+                    id={id}
+                    enableBottomSheet={
+                      !mypageInfo?.nickname === item.user_nickname
+                    }
+                  />
+                  <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
+                </View>
+              )
+            : undefined
+        }
+        ListFooterComponent={
+          activeTab === 'review' && (ratingStats?.total_reviews ?? 0) > 0 ? (
+            <View className='items-center mt-4 mb-6'>
+              <ReviewButton
+                onPress={() => {
+                  qc.setQueryData(
+                    ['product', 'ratingStats', Number(id)],
+                    ratingStats,
+                  );
+                  qc.setQueryData(['product', 'photo-preview', idNum], {
+                    previewPhotos: previewPhotoUrls ?? [],
+                    total_photo: reviewImageList?.pages[0]?.total_images ?? 0,
+                  });
+                  qc.setQueryData(['product', 'detail', idNum], {
+                    reviewAvg: data?.reviewAvg,
+                    reviewCount: data?.reviewCount,
+                  });
+                  router.push(`/product/${id}/review/allReview`);
+                }}
+                count={ratingStats?.total_reviews ?? 0}
+              />
+            </View>
+          ) : (
+            <View style={{ height: 24 }} />
+          )
+        }
+      />
+      {/* data.coupang */}
+      <CoupangTabBar id={id} coupangUrl='https://naver.com' />
+      <PortalHost name='overlay-top' />
+      <DefaultModal
+        visible={showIsMyReviewModal}
+        message='이미 리뷰를 작성하셨어요.'
+        confirmText='확인'
+        onConfirm={() => setShowIsMyReviewModal(false)}
+        singleButton={true}
+      />
+      <ScrollToTopButton
+        scrollRef={{
+          current: {
+            scrollTo: ({ y, animated }: any) =>
+              listRef.current?.scrollToOffset({ offset: y, animated }),
+          },
+        }}
+        visible={showTopButton}
+      />
       <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
         <View className='px-[30px] mt-[30px] mb-[44px]'>
           <Text className='text-b-sm font-n-eb text-gray-900 mb-[25px]'>
@@ -474,7 +457,7 @@ export default function ProductDetail() {
           </Text>
         </View>
       </BottomSheetLayout>
-    </PortalProvider>
+    </SafeAreaView>
   );
 }
 

--- a/app/product/[id]/review/[reviewId]/photoReviewDetail.tsx
+++ b/app/product/[id]/review/[reviewId]/photoReviewDetail.tsx
@@ -4,7 +4,6 @@ import Navigation from '@/components/layout/Navigation';
 import ReviewItems from '@/components/page/product/productDetail/reviewItem';
 import { useGetPhotoReviewDetail } from '@/hooks/product/review/image/useGetPhotoReviewDetail';
 import { toCdnUrl } from '@/utils/cdn';
-import { PortalProvider } from '@gorhom/portal';
 import { useQueryClient } from '@tanstack/react-query';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -71,118 +70,116 @@ export default function PhotoReviewDetail() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: 'white' }}>
       <Stack.Screen options={{ headerShown: false }} />
-      <PortalProvider>
-        <Navigation
-          title='포토 리뷰 상세보기'
-          right={<XIcon width={18} height={18} />}
-          onRightPress={() => router.back()}
-        />
+      <Navigation
+        title='포토 리뷰 상세보기'
+        right={<XIcon width={18} height={18} />}
+        onRightPress={() => router.back()}
+      />
 
-        <ScrollView
-          keyboardShouldPersistTaps='handled'
-          nestedScrollEnabled
-          showsVerticalScrollIndicator={false}
+      <ScrollView
+        keyboardShouldPersistTaps='handled'
+        nestedScrollEnabled
+        showsVerticalScrollIndicator={false}
+      >
+        {/* 이미지 뷰어 (리뷰 내 이미지들) */}
+        <View
+          style={{ width: '100%', aspectRatio: 1, backgroundColor: 'black' }}
         >
-          {/* 이미지 뷰어 (리뷰 내 이미지들) */}
-          <View
-            style={{ width: '100%', aspectRatio: 1, backgroundColor: 'black' }}
-          >
-            <FlatList
-              ref={listRef}
-              data={images}
-              horizontal
-              pagingEnabled
-              initialScrollIndex={targetIndex}
-              getItemLayout={(_, i) => ({
-                length: SCREEN_W,
-                offset: SCREEN_W * i,
-                index: i,
-              })}
-              showsHorizontalScrollIndicator={false}
-              keyExtractor={(item, i) => (item?.url ?? '') + i}
-              renderItem={({ item }) => (
-                <View
-                  style={{
-                    width: SCREEN_W,
-                    height: '100%',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Image
-                    source={{ uri: toCdnUrl(item.url) }}
-                    style={{ width: '100%', height: '100%' }}
-                    resizeMode='cover'
-                  />
-                </View>
-              )}
-              onMomentumScrollEnd={onMomentumEnd}
-              onScrollToIndexFailed={(info) => {
-                setTimeout(() => {
-                  listRef.current?.scrollToIndex({
-                    index: info.index,
-                    animated: false,
-                  });
-                }, 0);
-              }}
-            />
-
-            {/* 우상단 인디케이터: 현재/전체 */}
-            <View
-              style={{
-                position: 'absolute',
-                right: 20,
-                top: 20,
-                borderRadius: 999,
-                backgroundColor: 'rgba(0,0,0,0.5)',
-                width: 48,
-                height: 24,
-                alignItems: 'center',
-                justifyContent: 'center',
-                paddingHorizontal: 8,
-                paddingVertical: 4,
-              }}
-            >
-              {/* FlatList의 onViewableItemsChanged로 실시간 인덱스 추적하려면 상태 추가 */}
-              <Text
-                className='text-white text-c3 font-n-bd'
-                style={{ color: 'white', fontSize: 12 }}
+          <FlatList
+            ref={listRef}
+            data={images}
+            horizontal
+            pagingEnabled
+            initialScrollIndex={targetIndex}
+            getItemLayout={(_, i) => ({
+              length: SCREEN_W,
+              offset: SCREEN_W * i,
+              index: i,
+            })}
+            showsHorizontalScrollIndicator={false}
+            keyExtractor={(item, i) => (item?.url ?? '') + i}
+            renderItem={({ item }) => (
+              <View
+                style={{
+                  width: SCREEN_W,
+                  height: '100%',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
               >
-                {currentIndex + 1} / {reviewDetail?.images.length ?? 0}
-              </Text>
-            </View>
-          </View>
+                <Image
+                  source={{ uri: toCdnUrl(item.url) }}
+                  style={{ width: '100%', height: '100%' }}
+                  resizeMode='cover'
+                />
+              </View>
+            )}
+            onMomentumScrollEnd={onMomentumEnd}
+            onScrollToIndexFailed={(info) => {
+              setTimeout(() => {
+                listRef.current?.scrollToIndex({
+                  index: info.index,
+                  animated: false,
+                });
+              }, 0);
+            }}
+          />
 
-          {/* 리뷰 메타 + 본문 */}
-          {reviewDetail && (
-            <ReviewItems
-              reviewItem={{
-                id: idNum,
-                reviewId: reviewIdNum,
-                name: reviewDetail.user.nickname ?? '',
-                date: reviewDetail.date ?? '-',
-                isEdited: reviewDetail.updated,
-                content: reviewDetail.review ?? '',
-                rating: reviewDetail.rate ?? 0,
-                images: reviewDetail.images ? [reviewDetail.images] : [],
-              }}
-              isPhoto={false}
-              isMore={false}
-            />
-          )}
-          <View className='items-center'>
-            <ReviewButton
-              onPress={() =>
-                router.push({
-                  pathname: '/product/[id]/review/allReview',
-                  params: { id: String(id) },
-                })
-              }
-              count={reviewCount?.reviewCount ?? 0}
-            />
+          {/* 우상단 인디케이터: 현재/전체 */}
+          <View
+            style={{
+              position: 'absolute',
+              right: 20,
+              top: 20,
+              borderRadius: 999,
+              backgroundColor: 'rgba(0,0,0,0.5)',
+              width: 48,
+              height: 24,
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingHorizontal: 8,
+              paddingVertical: 4,
+            }}
+          >
+            {/* FlatList의 onViewableItemsChanged로 실시간 인덱스 추적하려면 상태 추가 */}
+            <Text
+              className='text-white text-c3 font-n-bd'
+              style={{ color: 'white', fontSize: 12 }}
+            >
+              {currentIndex + 1} / {reviewDetail?.images.length ?? 0}
+            </Text>
           </View>
-        </ScrollView>
-      </PortalProvider>
+        </View>
+
+        {/* 리뷰 메타 + 본문 */}
+        {reviewDetail && (
+          <ReviewItems
+            reviewItem={{
+              id: idNum,
+              reviewId: reviewIdNum,
+              name: reviewDetail.user.nickname ?? '',
+              date: reviewDetail.date ?? '-',
+              isEdited: reviewDetail.updated,
+              content: reviewDetail.review ?? '',
+              rating: reviewDetail.rate ?? 0,
+              images: reviewDetail.images ? [reviewDetail.images] : [],
+            }}
+            isPhoto={false}
+            isMore={false}
+          />
+        )}
+        <View className='items-center'>
+          <ReviewButton
+            onPress={() =>
+              router.push({
+                pathname: '/product/[id]/review/allReview',
+                params: { id: String(id) },
+              })
+            }
+            count={reviewCount?.reviewCount ?? 0}
+          />
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }

--- a/app/product/[id]/review/allReview.tsx
+++ b/app/product/[id]/review/allReview.tsx
@@ -10,7 +10,7 @@ import colors from '@/constants/color';
 import { useParseReviewIdFromImage } from '@/hooks/product/review/image/useParseReviewIdFromImage';
 import { useProductReviewsInfinite } from '@/hooks/product/review/useGetProductReview';
 import BottomSheet from '@gorhom/bottom-sheet';
-import { PortalProvider } from '@gorhom/portal';
+
 import { useQueryClient } from '@tanstack/react-query';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -71,169 +71,163 @@ export default function allReview() {
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
-      <PortalProvider>
-        <Navigation
-          title='리뷰 전체보기'
-          left={
-            <ArrowLeftIcon width={20} height={20} fill={colors.gray[900]} />
-          }
-          onLeftPress={() => router.back()}
-        />
+      <Navigation
+        title='리뷰 전체보기'
+        left={<ArrowLeftIcon width={20} height={20} fill={colors.gray[900]} />}
+        onLeftPress={() => router.back()}
+      />
 
-        <FlatList
-          ref={listRef}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          key={sort}
-          data={items ?? []}
-          keyExtractor={(it, i) => String(it?.review_id ?? `p-${i}`)}
-          onEndReached={onEndReached}
-          onEndReachedThreshold={0.4}
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 24 }}
-          /* 상단 고정 영역 */
-          ListHeaderComponent={
-            <View className='bg-white p-5 pb-0'>
-              {/* 리뷰 전체보기 타이틀 */}
-              <View className='flex-row items-center justify-between mb-[15px]'>
-                <View className='flex-row items-center'>
-                  <Text className='text-b-md font-extrabold text-gray-700 mr-[8px]'>
-                    리뷰 {cachedRatingStats?.reviewCount ?? 0}개
-                  </Text>
-                  <StarIcon width={20} height={20} />
-                  <Text className='text-b-md font-extrabold text-gray-700 ml-[2px]'>
-                    ({cachedRatingStats?.reviewAvg ?? 0})
-                  </Text>
-                </View>
+      <FlatList
+        ref={listRef}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        key={sort}
+        data={items ?? []}
+        keyExtractor={(it, i) => String(it?.review_id ?? `p-${i}`)}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.4}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 24 }}
+        /* 상단 고정 영역 */
+        ListHeaderComponent={
+          <View className='bg-white p-5 pb-0'>
+            {/* 리뷰 전체보기 타이틀 */}
+            <View className='flex-row items-center justify-between mb-[15px]'>
+              <View className='flex-row items-center'>
+                <Text className='text-b-md font-extrabold text-gray-700 mr-[8px]'>
+                  리뷰 {cachedRatingStats?.reviewCount ?? 0}개
+                </Text>
+                <StarIcon width={20} height={20} />
+                <Text className='text-b-md font-extrabold text-gray-700 ml-[2px]'>
+                  ({cachedRatingStats?.reviewAvg ?? 0})
+                </Text>
               </View>
-
-              {/* 리뷰 전체보기 사진 그리드 */}
-              <View>
-                <View className='pb-5'>
-                  <PhotoCard
-                    images={cachedPhotoPreview?.previewPhotos ?? []}
-                    total_photo={cachedPhotoPreview?.total_photo}
-                    maxPreview={6}
-                    onPressPhoto={(idx) => {
-                      const imageUrl = cachedPhotoPreview?.previewPhotos?.[idx];
-                      if (!imageUrl) return;
-
-                      // 사진 상세로 이동 (ProductDetail에서 쓰던 라우트와 동일)
-                      router.push({
-                        pathname:
-                          '/product/[id]/review/[reviewId]/photoReviewDetail',
-                        params: {
-                          id: String(id),
-                          reviewId: parseReviewId(imageUrl),
-                          imageUrl,
-                          index: idx,
-                        },
-                      });
-                    }}
-                    onPressMore={() =>
-                      router.push(`/product/${id}/review/photo/allList`)
-                    }
-                  />
-                </View>
-                <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
-              </View>
-
-              {/* 정렬 */}
-              <View>
-                <View className='py-[12px]'>
-                  <Pressable
-                    onPress={openSheet}
-                    hitSlop={8}
-                    className='flex-row items-center '
-                  >
-                    <Text className='text-b-sm font-bold mr-[3px]'>
-                      {
-                        SORT_OPTIONS.find((option) => option.key === sort)
-                          ?.label
-                      }
-                    </Text>
-                    <ArrowDownIcon />
-                  </Pressable>
-                </View>
-                <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
-              </View>
-
-              <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
-                <View className='px-5 pt-[30px] pb-[44px]'>
-                  {SORT_OPTIONS.map((opt) => {
-                    const active = sort === opt.key;
-                    return (
-                      <Pressable
-                        key={opt.key}
-                        onPress={() => {
-                          setSort(opt.key as 'time' | 'high' | 'low');
-                          closeSheet();
-                        }}
-                        hitSlop={8}
-                        accessibilityRole='button'
-                        accessibilityState={{ selected: active }}
-                      >
-                        <View className='flex-row items-center justify-between mb-[25px]'>
-                          <Text
-                            className={`text-b-sm font-bold ${active ? 'text-gray-900' : 'text-gray-400'}`}
-                          >
-                            {opt.label}
-                          </Text>
-                          {active && (
-                            <Svg
-                              width={18}
-                              height={18}
-                              viewBox='0 0 18 18'
-                              fill='none'
-                            >
-                              <Path
-                                d='M16.5 4.5L6.5 15L1.5 9'
-                                stroke={'#181A1B'}
-                                strokeWidth={1.5}
-                                strokeLinecap='round'
-                                strokeLinejoin='round'
-                              />
-                            </Svg>
-                          )}
-                        </View>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-              </BottomSheetLayout>
             </View>
-          }
-          renderItem={({ item, index }) => (
-            <View key={index}>
-              <ReviewItems
-                reviewItem={{
-                  id: item.review_id ?? '',
-                  reviewId: item.review_id ?? '',
-                  name: item.user_nickname ?? '',
-                  date: item.date ?? '-',
-                  isEdited: item.updated,
-                  content: item.review ?? '',
-                  rating: item.rate ?? 0,
-                  images: item.images ?? [],
-                }}
-                id={id}
-              />
+
+            {/* 리뷰 전체보기 사진 그리드 */}
+            <View>
+              <View className='pb-5'>
+                <PhotoCard
+                  images={cachedPhotoPreview?.previewPhotos ?? []}
+                  total_photo={cachedPhotoPreview?.total_photo}
+                  maxPreview={6}
+                  onPressPhoto={(idx) => {
+                    const imageUrl = cachedPhotoPreview?.previewPhotos?.[idx];
+                    if (!imageUrl) return;
+
+                    // 사진 상세로 이동 (ProductDetail에서 쓰던 라우트와 동일)
+                    router.push({
+                      pathname:
+                        '/product/[id]/review/[reviewId]/photoReviewDetail',
+                      params: {
+                        id: String(id),
+                        reviewId: parseReviewId(imageUrl),
+                        imageUrl,
+                        index: idx,
+                      },
+                    });
+                  }}
+                  onPressMore={() =>
+                    router.push(`/product/${id}/review/photo/allList`)
+                  }
+                />
+              </View>
               <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
             </View>
-          )}
-          ListFooterComponent={
-            <View
-              style={{
-                height: 56,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              {isFetchingNextPage ? <Text>불러오는 중…</Text> : null}
+
+            {/* 정렬 */}
+            <View>
+              <View className='py-[12px]'>
+                <Pressable
+                  onPress={openSheet}
+                  hitSlop={8}
+                  className='flex-row items-center '
+                >
+                  <Text className='text-b-sm font-bold mr-[3px]'>
+                    {SORT_OPTIONS.find((option) => option.key === sort)?.label}
+                  </Text>
+                  <ArrowDownIcon />
+                </Pressable>
+              </View>
+              <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
             </View>
-          }
-        />
-      </PortalProvider>
+
+            <BottomSheetLayout snapPoints={snapPoints} sheetRef={sheetRef}>
+              <View className='px-5 pt-[30px] pb-[44px]'>
+                {SORT_OPTIONS.map((opt) => {
+                  const active = sort === opt.key;
+                  return (
+                    <Pressable
+                      key={opt.key}
+                      onPress={() => {
+                        setSort(opt.key as 'time' | 'high' | 'low');
+                        closeSheet();
+                      }}
+                      hitSlop={8}
+                      accessibilityRole='button'
+                      accessibilityState={{ selected: active }}
+                    >
+                      <View className='flex-row items-center justify-between mb-[25px]'>
+                        <Text
+                          className={`text-b-sm font-bold ${active ? 'text-gray-900' : 'text-gray-400'}`}
+                        >
+                          {opt.label}
+                        </Text>
+                        {active && (
+                          <Svg
+                            width={18}
+                            height={18}
+                            viewBox='0 0 18 18'
+                            fill='none'
+                          >
+                            <Path
+                              d='M16.5 4.5L6.5 15L1.5 9'
+                              stroke={'#181A1B'}
+                              strokeWidth={1.5}
+                              strokeLinecap='round'
+                              strokeLinejoin='round'
+                            />
+                          </Svg>
+                        )}
+                      </View>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </BottomSheetLayout>
+          </View>
+        }
+        renderItem={({ item, index }) => (
+          <View key={index}>
+            <ReviewItems
+              reviewItem={{
+                id: item.review_id ?? '',
+                reviewId: item.review_id ?? '',
+                name: item.user_nickname ?? '',
+                date: item.date ?? '-',
+                isEdited: item.updated,
+                content: item.review ?? '',
+                rating: item.rate ?? 0,
+                images: item.images ?? [],
+              }}
+              id={id}
+            />
+            <View className='w-[200%] h-[1px] left-[-50%] bg-gray-50' />
+          </View>
+        )}
+        ListFooterComponent={
+          <View
+            style={{
+              height: 56,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {isFetchingNextPage ? <Text>불러오는 중…</Text> : null}
+          </View>
+        }
+      />
+
       <ScrollToTopButton
         scrollRef={{
           current: {

--- a/components/page/product/productDetail/BottomSeetLayout.tsx
+++ b/components/page/product/productDetail/BottomSeetLayout.tsx
@@ -2,9 +2,8 @@ import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
-import { Portal } from '@gorhom/portal';
-import React, { useCallback } from 'react';
-
+import React, { useCallback, useState } from 'react';
+import { View } from 'react-native';
 interface BottomSheetLayoutProps {
   children: React.ReactNode;
   snapPoints?: number[];
@@ -16,6 +15,8 @@ export default function BottomSheetLayout({
   snapPoints,
   sheetRef,
 }: BottomSheetLayoutProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
   const renderBackdrop = useCallback(
     (props: any) => (
       <BottomSheetBackdrop
@@ -31,21 +32,32 @@ export default function BottomSheetLayout({
     ),
     [],
   );
+
+  const handleChange = useCallback((index: number) => {
+    console.log(index);
+    setIsOpen(index >= 0);
+  }, []);
+
   return (
-    <Portal>
+    <View
+      pointerEvents={isOpen ? 'auto' : 'none'}
+      style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+    >
       <BottomSheet
         ref={sheetRef}
         index={-1}
         snapPoints={snapPoints}
         enablePanDownToClose
+        onChange={handleChange}
         backdropComponent={renderBackdrop}
         backgroundStyle={{
           borderTopLeftRadius: 12,
           borderTopRightRadius: 12,
         }}
+        handleIndicatorStyle={{ opacity: 1 }}
       >
-        <BottomSheetView className=''>{children}</BottomSheetView>
+        <BottomSheetView>{children}</BottomSheetView>
       </BottomSheet>
-    </Portal>
+    </View>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
- #119 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 바텀시트 렌더링 구조로 인해 일부 안드로이드에서 터치가 안되는 현상이 발견되었습니다.
원인은 바텀시트가 포인터 이벤트를 가로채는 레이어 구조로 렌더링되면서, 하위 컴포넌트의 터치 이벤트가 차단되는 문제였습니다.

이를 해결하기 위해

기존에 사용하던 portal 기반 렌더링 구조를 제거하고

바텀시트가 화면 상에서 직접 렌더링되도록 구조를 수정했으며

터치 이벤트가 필요한 영역이 정상적으로 이벤트를 전달받도록 레이아웃/레이어 구조를 개선했습니다.

해당 수정으로 안드로이드 환경에서도 터치가 정상 동작하는 것을 확인했습니다.

바텀시트 렌더링 구조를 수정하고

터치 이벤트가 필요한 영역이 정상적으로 이벤트를 전달받도록 레이아웃/레이어 구조를 개선했습니다.

해당 수정으로 안드로이드 환경에서도 터치가 정상 동작하는 것을 확인했습니다.

## 🗣️ 팀원에게 공유할 내용
- 안드로이드에서만 발생하던 이슈로, iOS에는 영향 없습니다.
-  바텀시트 또는 overlay UI 구현 시 portal 사용 여부와 터치 이벤트 전달 구조를 함께 고려하면 좋을 것 같습니다.

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->