### PR TITLE
fix: hide password change UI for social login users

### DIFF
--- a/app/(tabs)/mypage/index.tsx
+++ b/app/(tabs)/mypage/index.tsx
@@ -23,6 +23,8 @@ export default function Mypage() {
 
   const [isLogin, setIsLogin] = useState(true);
 
+  const canChangePassword = mypageInfo?.login_type === 'email';
+
   const handleOAuthPasswordPress = () => {
     router.push('/mypage/password');
   };
@@ -70,6 +72,8 @@ export default function Mypage() {
     }, [fetchMypage]),
   );
 
+  console.log(mypageInfo?.login_type);
+
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Navigation title='마이페이지' />
@@ -89,10 +93,12 @@ export default function Mypage() {
                 label='아이디'
                 value={`${mypageInfo?.email} (${mypageInfo?.login_type} 로그인)`}
               />
-              <SettingItem
-                label='비밀번호 변경'
-                onPress={handleOAuthPasswordPress}
-              />
+              {canChangePassword && (
+                <SettingItem
+                  label='비밀번호 변경'
+                  onPress={handleOAuthPasswordPress}
+                />
+              )}
             </SettingSection>
 
             <SettingSection title='리뷰' topBorder>

--- a/types/models/user.ts
+++ b/types/models/user.ts
@@ -1,6 +1,6 @@
 export interface IUser {
   nickname: string;
   email: string;
-  login_type: string;
+  login_type: string; // kakao, apple, email
   review_count: number;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
- #132 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 소셜 로그인 계정(login_type !== 'email')의 경우 마이페이지에서 비밀번호 변경 UI가 노출되지 않도록 조건부 렌더링 처리하였습니다.
- 이메일 로그인 계정만 비밀번호 변경 메뉴 접근 가능하도록 수정하였습니다.

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->