### PR TITLE
fix: expand touch area for icon buttons

### DIFF
--- a/app/(tabs)/category/index.tsx
+++ b/app/(tabs)/category/index.tsx
@@ -94,12 +94,12 @@ export default function Category() {
             <Pressable
               key={cat}
               onPress={() => setSelectedBigCategory(cat)}
-              className={`items-start py-4 ${
+              className={`items-start py-[16px] ${
                 selectedBigCategory === cat ? 'bg-white' : 'bg-gray-100'
               }`}
             >
               <Text
-                className={`text-md pl-3 pr-3 ${
+                className={`text-sm pl-3 pr-3 ${
                   selectedBigCategory === cat
                     ? 'text-gray-900 font-n-bd'
                     : 'text-gray-400 font-n-bd'
@@ -113,29 +113,29 @@ export default function Category() {
         </ScrollView>
 
         <View className='flex-1'>
-          <View className='flex-row justify-between items-center px-4 pt-2 pb-1'>
-            <Text className='text-lg font-n-bd text-gray-900'>
+          <Pressable
+            className='flex-row justify-between items-center px-4 pt-[15px] pb-[17px]'
+            onPress={() => goToList()}
+          >
+            <Text className='text-md font-n-bd text-gray-900'>
               {selectedBigCategory}
             </Text>
-            <Pressable
-              onPress={() => goToList()}
-              className='flex-row items-center pr-1'
-            >
+            <View className='flex-row items-center'>
               <ViewAllIcon width={13} height={13} color={colors.gray[900]} />
-            </Pressable>
-          </View>
+            </View>
+          </Pressable>
 
           <FlatList
             data={subCategoriesMap[selectedBigCategory] || []}
             keyExtractor={(item) => item}
             renderItem={({ item }) => (
               <Pressable
-                className='py-2.5 px-4'
+                className='py-2 px-4'
                 onPress={() => {
                   goToList(item);
                 }}
               >
-                <Text className='text-sm text-gray-900 font-n-bd'>{item}</Text>
+                <Text className='text-c1 text-gray-900 font-n-bd'>{item}</Text>
               </Pressable>
             )}
             showsVerticalScrollIndicator={false}

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -25,7 +25,10 @@ export default function Home() {
 
           <View className='flex-row'>
             <View className='flex-row'>
-              <Pressable onPress={() => router.push('/home/search')}>
+              <Pressable
+                hitSlop={8}
+                onPress={() => router.push('/home/search')}
+              >
                 <MagnifierIcon color={colors.gray[900]} />
               </Pressable>
             </View>
@@ -46,14 +49,17 @@ export default function Home() {
         <View className='mt-2 mb-12'>
           <View className='mx-6 flex-row justify-between items-center'>
             <Text className='text-base font-n-bd'>현재 급상승 랭킹</Text>
-            <GoRankingIcon
+            <Pressable
+              hitSlop={8}
               onPress={() =>
                 router.push({
                   pathname: '/(tabs)/home/ranking',
                   params: { initialTab: 'daily' },
                 })
               }
-            />
+            >
+              <GoRankingIcon />
+            </Pressable>
           </View>
 
           <ProductRankingCarousel

--- a/app/(tabs)/home/ranking.tsx
+++ b/app/(tabs)/home/ranking.tsx
@@ -124,7 +124,7 @@ export default function Ranking() {
       <Navigation
         title='랭킹'
         left={<ArrowLeftIcon width={20} height={20} fill={colors.gray[900]} />}
-        onLeftPress={() => router.push('/(tabs)/home')}
+        onLeftPress={() => router.back()}
         right={<SearchIcon width={20} height={20} fill={colors.gray[900]} />}
         onRightPress={() => router.push('/home/search')}
       />

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -44,6 +44,7 @@ export default function Navigation({
       <Pressable
         onPress={onRightPress}
         className='p-1 flex-row items-center gap-6'
+        hitSlop={8}
       >
         {right || <Text></Text>}
         {secondRight && (secondRight || <Text></Text>)}


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #137 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- hitSlop을 사용해 아이콘/버튼의 클릭(터치) 영역을 확장

- UI 크기나 레이아웃 변화 없이 터치 인식 범위만 개선

- 작은 아이콘 버튼에서 발생하던 클릭 불편함 해소

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->