### PR TITLE
최근 기록 클릭 에러 수정

### DIFF
--- a/components/page/home/SearchBar.tsx
+++ b/components/page/home/SearchBar.tsx
@@ -47,6 +47,7 @@ export default function SearchBar({
   };
 
   const handleRecentSearchPress = (search: string) => {
+    setIsFocused(false); // 여기서 닫기
     inputRef.current?.blur();
     onRecentSearchPress?.(search);
   };
@@ -73,7 +74,6 @@ export default function SearchBar({
               LayoutAnimation.configureNext(
                 LayoutAnimation.Presets.easeInEaseOut,
               );
-              setIsFocused(false);
               onBlur?.();
             }}
             autoFocus={true}
@@ -124,21 +124,20 @@ export default function SearchBar({
                 ItemSeparatorComponent={() => <View style={{ width: 8 }} />}
                 contentContainerStyle={{ paddingVertical: 4 }}
                 renderItem={({ item }) => (
-                  <Pressable
-                    onPress={() => handleRecentSearchPress(item)}
-                    className='flex-row items-center bg-white border-[0.5px] border-gray-200 rounded-full pl-4 pr-2 py-1'
-                  >
-                    <Text
-                      className='flex-1 text-sm text-gray-900'
-                      numberOfLines={1}
+                  <View className='flex-row items-center bg-white border-[0.5px] border-gray-200 rounded-full pl-4 pr-2 py-1'>
+                    <Pressable
+                      onPress={() => handleRecentSearchPress(item)}
+                      className='flex-1'
                     >
-                      {item}
-                    </Text>
+                      <Text className='text-sm text-gray-900' numberOfLines={1}>
+                        {item}
+                      </Text>
+                    </Pressable>
 
                     <Pressable
                       onPress={() => onRemoveRecentSearch?.(item)}
                       className='p-1 ml-2 mr-1'
-                      onPressIn={(e) => e.stopPropagation()}
+                      hitSlop={8}
                     >
                       <CloseIcon
                         width={16}
@@ -146,7 +145,7 @@ export default function SearchBar({
                         color={colors.gray[700]}
                       />
                     </Pressable>
-                  </Pressable>
+                  </View>
                 )}
               />
             </View>


### PR DESCRIPTION
## 🔗 관련 이슈
- #139

## 📌 PR 내용

- onBlur 실행 시 setIsFocused(false)가 실행되어 리스트 전체가 언마운트됨(Pressable onPress 실행 전 컴포넌트 해제)
- onBlur에서 setIsFocused(false)를 제거하고 handleRecentSearchPress에 추가

## 🗣️ 팀원에게 공유할 내용