### PR TITLE
feat: 소셜로그인 이용약관 동의 플로우 수정 및 애플로그인 반영

### DIFF
--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -24,10 +24,11 @@ export default function Home() {
     if (!mainScreenInfo) return;
 
     // 이미 약관 화면이면 스킵(루프 방지)
-    if (pathname?.includes('/oauth')) return;
+    if (pathname?.includes('/terms')) return;
 
+    // ✅ 약관 미동의인 경우에만 강제 이동
     if (isTermsAgreed === false) {
-      router.replace({ pathname: '/oauth', params: { mode: 'terms' } }); // 약관 동의 화면 라우트로
+      router.replace({ pathname: '/terms', params: { mode: 'terms' } });
     }
   }, [isLoading, mainScreenInfo, isTermsAgreed, pathname]);
 

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -5,10 +5,10 @@ import BannerCarousel from '@/components/page/home/BannerCarousel';
 import HomeFooter from '@/components/page/home/HomeFooter';
 import ProductRankingCarousel from '@/components/page/home/ProductRankingCarousel';
 import TagsView from '@/components/page/home/TagsView';
-import { useFetchMainScreenQuery } from '@/hooks/useProductQueries';
-
 import { bannerData } from '@/constants/banner';
-import { router } from 'expo-router';
+import { useFetchMainScreenQuery } from '@/hooks/useProductQueries';
+import { router, usePathname } from 'expo-router';
+import { useEffect } from 'react';
 
 import colors from '@/constants/color';
 import { Pressable, ScrollView, Text, View } from 'react-native';
@@ -16,11 +16,25 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Home() {
   const { data: mainScreenInfo, isLoading } = useFetchMainScreenQuery();
+  const isTermsAgreed = mainScreenInfo?.user?.isTermsAgreed;
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!mainScreenInfo) return;
+
+    // 이미 약관 화면이면 스킵(루프 방지)
+    if (pathname?.includes('/oauth')) return;
+
+    if (isTermsAgreed === false) {
+      router.replace({ pathname: '/oauth', params: { mode: 'terms' } }); // 약관 동의 화면 라우트로
+    }
+  }, [isLoading, mainScreenInfo, isTermsAgreed, pathname]);
 
   return (
-    <SafeAreaView className='bg-white flex-1' edges={['top']}>
+    <SafeAreaView className='flex-1 bg-white' edges={['top']}>
       <ScrollView className='flex-1'>
-        <View className='flex-row justify-between items-center px-6 pt-4'>
+        <View className='flex-row items-center justify-between px-6 pt-4'>
           <LogoIcon width={80} height={30} />
 
           <View className='flex-row'>
@@ -47,7 +61,7 @@ export default function Home() {
         </View>
 
         <View className='mt-2 mb-12'>
-          <View className='mx-6 flex-row justify-between items-center'>
+          <View className='flex-row items-center justify-between mx-6'>
             <Text className='text-base font-n-bd'>현재 급상승 랭킹</Text>
             <Pressable
               hitSlop={8}

--- a/app/auth/login/index.tsx
+++ b/app/auth/login/index.tsx
@@ -1,22 +1,12 @@
-import CircleCheckGrayIcon from '@/assets/icons/auth/ic_circle_check_gray.svg';
-import CircleCheckGreenIcon from '@/assets/icons/auth/ic_circle_check_green.svg';
 import XIcon from '@/assets/icons/auth/ic_emergency_x.svg';
 import AppleIcon from '@/assets/icons/ic_apple.svg';
-import RightArrowIcon from '@/assets/icons/ic_arrow_right.svg';
 import EmailIcon from '@/assets/icons/ic_email.svg';
 import Logo from '@/assets/icons/ic_logo_start.svg';
 import LoginButton from '@/components/common/buttons/LoginButton';
-import { LongButton } from '@/components/common/buttons/LongButton';
 import Navigation from '@/components/layout/Navigation';
-import { HomeFooterModal } from '@/components/page/home/HomeFooterModal';
 import KakaoLoginButton from '@/components/page/login/kakaoLogin';
-import BottomSheetLayout from '@/components/page/product/productDetail/BottomSheet/BottomSheetLayout';
-import { useKakaoLogin } from '@/hooks/auth/kakao/useKakaoLogin';
 import { useAppleLogin } from '@/hooks/auth/useAppleLogin';
-import BottomSheet from '@gorhom/bottom-sheet';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Stack, useFocusEffect, useRouter } from 'expo-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Stack, useRouter } from 'expo-router';
 import {
   Platform,
   Pressable,
@@ -26,149 +16,18 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import Svg, { Path } from 'react-native-svg';
-
-const KAKAO_FLOW_KEY = 'kakao_flow';
-const KAKAO_PRELOGIN_DONE_KEY = 'kakao_prelogin_done';
-const KAKAO_IS_NEW_USER_KEY = 'kakao_is_new_user';
-
-const TERMS: { id: string; terms: string; essential: boolean }[] = [
-  { id: 'service', terms: '이용 약관 동의', essential: true },
-  { id: 'privacy', terms: '개인정보 수집/이용 동의', essential: true },
-  { id: 'age', terms: '연령 제한 및 법적 규정 동의', essential: true },
-  { id: 'appUsage', terms: '앱 이용 정보 수집 동의', essential: true },
-  { id: 'notification', terms: '알림 및 푸시 알림 동의', essential: false },
-];
 
 export default function Index({ emergency }: { emergency?: string }) {
   const { width, height } = useWindowDimensions();
   const isIOS = Platform.OS === 'ios';
   const aspectRatio = width / height;
-
   const router = useRouter();
   const appleLogin = useAppleLogin();
-  const [forceReauth, setForceReauth] = useState(false);
-  const [checkedSet, setCheckedSet] = useState<Set<number>>(new Set());
-  const [isTermsModalVisible, setIsTermsModalVisible] = useState(false);
-  const [selectedTerm, setSelectedTerm] = useState<string>('');
-  const { mutate: finalizeLogin } = useKakaoLogin();
 
-  // ===== BottomSheet =====
-  const sheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => [462], []);
-  const openSheet = useCallback(async () => {
-    await AsyncStorage.setItem('pendingAgreement', 'kakao_signup');
-    sheetRef.current?.snapToIndex?.(0);
-  }, []);
   const isTabletRatio =
     Math.abs(aspectRatio - 4 / 3) < 0.2 || Math.abs(aspectRatio - 3 / 4) < 0.2;
 
   const scrollClassName = isTabletRatio ? 'pb-[100px]' : '';
-
-  useEffect(() => {
-    AsyncStorage.getItem('forceReauth').then((value) => {
-      if (value === 'true') {
-        setForceReauth(true);
-        AsyncStorage.removeItem('forceReauth');
-      }
-    });
-  }, []);
-
-  useFocusEffect(
-    useCallback(() => {
-      let cancelled = false;
-
-      (async () => {
-        const flow = await AsyncStorage.getItem(KAKAO_FLOW_KEY);
-        if (flow !== 'in_progress') return;
-
-        const preloginDone = await AsyncStorage.getItem(
-          KAKAO_PRELOGIN_DONE_KEY,
-        );
-        if (preloginDone !== 'true') return;
-
-        const isNew = await AsyncStorage.getItem(KAKAO_IS_NEW_USER_KEY);
-
-        if (cancelled) return;
-
-        if (isNew === 'true') {
-          await AsyncStorage.removeItem(KAKAO_PRELOGIN_DONE_KEY);
-          await openSheet();
-          return;
-        }
-
-        // 기존 유저면 서버 로그인 진행
-        finalizeLogin(undefined, {
-          onSuccess: async () => {
-            await AsyncStorage.multiRemove([
-              KAKAO_FLOW_KEY,
-              KAKAO_PRELOGIN_DONE_KEY,
-              KAKAO_IS_NEW_USER_KEY,
-            ]);
-            router.replace('/home');
-          },
-          onError: async () => {
-            await AsyncStorage.multiRemove([
-              KAKAO_FLOW_KEY,
-              KAKAO_PRELOGIN_DONE_KEY,
-              KAKAO_IS_NEW_USER_KEY,
-            ]);
-          },
-        });
-      })();
-
-      return () => {
-        cancelled = true;
-      };
-    }, [finalizeLogin, openSheet, router]),
-  );
-
-  // 필수 항목 인덱스
-  const essentialIdxs = useMemo(
-    () => TERMS.map((t, i) => (t.essential ? i : -1)).filter((i) => i !== -1),
-    [],
-  );
-
-  // 전체 선택 여부 / 필수 항목 모두 선택 여부
-  const isAllChecked = checkedSet.size === TERMS.length;
-  const isEssentialChecked = useMemo(
-    () => essentialIdxs.every((i) => checkedSet.has(i)),
-    [checkedSet, essentialIdxs],
-  );
-
-  // 개별 토글
-  const toggleItem = (idx: number) => {
-    setCheckedSet((prev) => {
-      const next = new Set(prev);
-      if (next.has(idx)) next.delete(idx);
-      else next.add(idx);
-      return next;
-    });
-  };
-
-  // 전체 토글
-  const toggleAll = () => {
-    setCheckedSet((prev) =>
-      prev.size === TERMS.length ? new Set() : new Set(TERMS.map((_, i) => i)),
-    );
-  };
-  // const onPressSubmit = async () => {
-  //   await AsyncStorage.removeItem('pendingAgreement');
-  //   finalizeLogin(undefined, {
-  //     onSuccess: async () => {
-  //       await AsyncStorage.multiRemove([
-  //         'kakao_flow',
-  //         'kakao_prelogin_done',
-  //         'kakao_is_new_user',
-  //       ]);
-  //       sheetRef.current?.close?.();
-  //       router.replace('/home');
-  //     },
-  //     onError: (err: unknown) => {
-  //       console.log('finalizeLogin error:', err);
-  //     },
-  //   });
-  // };
 
   return (
     <SafeAreaView className='flex-1 bg-white'>
@@ -181,20 +40,20 @@ export default function Index({ emergency }: { emergency?: string }) {
         contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
         className={scrollClassName}
       >
-        <View className='flex-1 items-center'>
+        <View className='items-center flex-1'>
           <View className='items-center w-full justify-center h-[64.98%]'>
             <Logo width={112} height={33} />
             <View className='flex-col items-center mt-[18px] '>
-              <Text className='text-b-sm font-n-rg text-gray-900'>
+              <Text className='text-gray-900 text-b-sm font-n-rg'>
                 다이어트 필수 정보,
               </Text>
-              <Text className='text-b-sm font-n-rg text-gray-900'>
+              <Text className='text-gray-900 text-b-sm font-n-rg'>
                 보조제 성분부터 후기까지 한번에
               </Text>
             </View>
           </View>
 
-          <View className=' w-full px-5 flex-col space-y-3'>
+          <View className='flex-col w-full px-5 space-y-3 '>
             <KakaoLoginButton />
 
             {isIOS && (
@@ -228,7 +87,7 @@ export default function Index({ emergency }: { emergency?: string }) {
 
           {!emergency && (
             <View className='flex-row items-center justify-center mt-[10px]'>
-              <Text className='text-b-sm font-n-rg text-gray-500'>
+              <Text className='text-gray-500 text-b-sm font-n-rg'>
                 서비스가 궁금하시다면?
               </Text>
 
@@ -245,110 +104,6 @@ export default function Index({ emergency }: { emergency?: string }) {
           )}
         </View>
       </ScrollView>
-
-      <BottomSheetLayout
-        snapPoints={snapPoints}
-        sheetRef={sheetRef}
-        pressBehavior='none'
-        enablePanDownToClose={false}
-      >
-        {/* ===== 서비스 약관 동의 ===== */}
-        <View className='px-5 pt-[30px] pb-[45px]'>
-          <Pressable
-            onPress={toggleAll}
-            className='flex-row items-center mb-[28px] '
-            hitSlop={8}
-          >
-            {isAllChecked ? (
-              <CircleCheckGreenIcon className='mr-[11px]' />
-            ) : (
-              <CircleCheckGrayIcon className='mr-[11px]' />
-            )}
-
-            <Text className='text-b-md font-n-eb text-gray-700 items-center'>
-              서비스 이용 약관 동의(전체)
-            </Text>
-          </Pressable>
-
-          <View className='gap-y-[25px] mb-[25px]'>
-            {TERMS.map(({ id, terms, essential }, idx) => {
-              const checked = checkedSet.has(idx);
-              return (
-                <View
-                  key={idx}
-                  className='flex-row items-center justify-between'
-                >
-                  <Pressable
-                    onPress={() => toggleItem(idx)}
-                    className='flex-row items-center '
-                    hitSlop={8}
-                  >
-                    <Svg
-                      width={18}
-                      height={18}
-                      viewBox='0 0 18 18'
-                      fill='none'
-                      className='mr-[13px]'
-                    >
-                      <Path
-                        d='M16.5 4.5L6.5 15L1.5 9'
-                        stroke={checked ? '#50D88F' : '#C9CDD2'}
-                        strokeWidth={1.5}
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                      />
-                    </Svg>
-                    {essential ? (
-                      <Text
-                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                      >
-                        [필수]
-                      </Text>
-                    ) : (
-                      <Text
-                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                      >
-                        [선택]
-                      </Text>
-                    )}
-                    <Text
-                      className={`ml-[2px] font-n-bd text-b-sm ${
-                        !checked && 'text-b-sm text-gray-400'
-                      }`}
-                    >
-                      {terms}
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => {
-                      setIsTermsModalVisible(true);
-                      setSelectedTerm(id);
-                    }}
-                  >
-                    <RightArrowIcon />
-                  </Pressable>
-                </View>
-              );
-            })}
-          </View>
-          <LongButton
-            label='동의하고 계속하기'
-            disabled={!isEssentialChecked}
-          />
-        </View>
-      </BottomSheetLayout>
-      <HomeFooterModal
-        type={
-          selectedTerm as
-            | 'service'
-            | 'privacy'
-            | 'age'
-            | 'appUsage'
-            | 'notification'
-        }
-        visible={isTermsModalVisible}
-        onClose={() => setIsTermsModalVisible(false)}
-      />
     </SafeAreaView>
   );
 }

--- a/app/auth/signUp/result.tsx
+++ b/app/auth/signUp/result.tsx
@@ -1,10 +1,31 @@
 import Logo from '@/assets/icons/ic_logo_start.svg';
 import { LongButton } from '@/components/common/buttons/LongButton';
+import { patchTermsAgreed } from '@/services/auth/terms';
+import { useFocusEffect } from '@react-navigation/native';
 import { Stack, useRouter } from 'expo-router';
+import { useCallback, useRef } from 'react';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 const Result = () => {
   const router = useRouter();
+  const calledRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (calledRef.current) return;
+      calledRef.current = true;
+
+      const run = async () => {
+        try {
+          await patchTermsAgreed({ is_terms_agreed: true });
+        } catch (e) {
+          console.log('약관 동의 처리 실패', e);
+        }
+      };
+
+      run();
+    }, []),
+  );
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
@@ -12,13 +33,13 @@ const Result = () => {
         <Text className='mt-[75px] text-h-lg font-n-eb text-gray-700'>
           회원가입 완료
         </Text>
-        <View className='items-center w-full justify-center boer flex-1'>
+        <View className='items-center justify-center flex-1 w-full boer'>
           <Logo width={112} height={33} />
           <View className='flex-col items-center mt-[18px] '>
-            <Text className='text-b-sm font-n-rg text-gray-900'>
+            <Text className='text-gray-900 text-b-sm font-n-rg'>
               다이어트 필수 정보,
             </Text>
-            <Text className='text-b-sm font-n-rg text-gray-900'>
+            <Text className='text-gray-900 text-b-sm font-n-rg'>
               보조제 성분부터 후기까지 한번에
             </Text>
           </View>

--- a/app/oauth.tsx
+++ b/app/oauth.tsx
@@ -4,7 +4,8 @@ import CircleCheckGrayIcon from '@/assets/icons/auth/ic_circle_check_gray.svg';
 import CircleCheckGreenIcon from '@/assets/icons/auth/ic_circle_check_green.svg';
 import RightArrowIcon from '@/assets/icons/ic_arrow_right.svg';
 import { LongButton } from '@/components/common/buttons/LongButton';
-import { HomeFooterModal } from '@/components/page/login/home/HomeFooterModal';
+import Navigation from '@/components/layout/Navigation';
+import { HomeFooterModal } from '@/components/page/home/HomeFooterModal';
 import { useKakaoLogin } from '@/hooks/auth/kakao/useKakaoLogin';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Stack, useRouter } from 'expo-router';
@@ -87,7 +88,7 @@ export default function OAuth() {
 
   if (isLoading) {
     return (
-      <View className='flex-1 items-center justify-center'>
+      <View className='items-center justify-center flex-1'>
         <Text></Text>
       </View>
     );
@@ -123,92 +124,91 @@ export default function OAuth() {
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
-      <View>
-        {/* <Text>oauth 페이지 입니다</Text>
-      <Text>kakaoAccessToken : {kakaoAccessToken}</Text>
-      <Text>kakaoRefreshToken : {kakaoRefreshToken}</Text>
-      <Text>kakaoEmail : {kakaoEmail}</Text> */}
+      <Navigation title='서비스 이용 약관' />
+      <View className='flex-1'>
+        <View className='flex-col justify-between flex-1 px-5'>
+          <View>
+            {' '}
+            <Pressable
+              onPress={toggleAll}
+              className='flex-row items-center mb-[28px] '
+              hitSlop={8}
+            >
+              {isAllChecked ? (
+                <CircleCheckGreenIcon className='mr-[11px]' />
+              ) : (
+                <CircleCheckGrayIcon className='mr-[11px]' />
+              )}
 
-        <View className='px-5 pt-[30px] pb-[45px]'>
-          <Pressable
-            onPress={toggleAll}
-            className='flex-row items-center mb-[28px] '
-            hitSlop={8}
-          >
-            {isAllChecked ? (
-              <CircleCheckGreenIcon className='mr-[11px]' />
-            ) : (
-              <CircleCheckGrayIcon className='mr-[11px]' />
-            )}
-
-            <Text className='text-b-md font-n-eb text-gray-700 items-center'>
-              서비스 이용 약관 동의(전체)
-            </Text>
-          </Pressable>
-
-          <View className='gap-y-[25px] mb-[25px]'>
-            {TERMS.map(({ id, terms, essential }, idx) => {
-              const checked = checkedSet.has(idx);
-              return (
-                <View
-                  key={idx}
-                  className='flex-row items-center justify-between'
-                >
-                  <Pressable
-                    onPress={() => toggleItem(idx)}
-                    className='flex-row items-center '
-                    hitSlop={8}
+              <Text className='items-center text-gray-700 text-b-lg font-n-eb'>
+                서비스 이용 약관 동의(전체)
+              </Text>
+            </Pressable>
+            <View className='gap-y-[25px] mb-[25px]'>
+              {TERMS.map(({ id, terms, essential }, idx) => {
+                const checked = checkedSet.has(idx);
+                return (
+                  <View
+                    key={idx}
+                    className='flex-row items-center justify-between'
                   >
-                    <Svg
-                      width={18}
-                      height={18}
-                      viewBox='0 0 18 18'
-                      fill='none'
-                      className='mr-[13px]'
+                    <Pressable
+                      onPress={() => toggleItem(idx)}
+                      className='flex-row items-center '
+                      hitSlop={8}
                     >
-                      <Path
-                        d='M16.5 4.5L6.5 15L1.5 9'
-                        stroke={checked ? '#50D88F' : '#C9CDD2'}
-                        strokeWidth={1.5}
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                      />
-                    </Svg>
-                    {essential ? (
-                      <Text
-                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                      <Svg
+                        width={18}
+                        height={18}
+                        viewBox='0 0 18 18'
+                        fill='none'
+                        className='mr-[13px]'
                       >
-                        [필수]
-                      </Text>
-                    ) : (
+                        <Path
+                          d='M16.5 4.5L6.5 15L1.5 9'
+                          stroke={checked ? '#50D88F' : '#C9CDD2'}
+                          strokeWidth={1.5}
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                        />
+                      </Svg>
+                      {essential ? (
+                        <Text
+                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                        >
+                          [필수]
+                        </Text>
+                      ) : (
+                        <Text
+                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                        >
+                          [선택]
+                        </Text>
+                      )}
                       <Text
-                        className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
+                        className={`ml-[2px] font-n-bd text-b-sm ${
+                          !checked && 'text-b-sm text-gray-400'
+                        }`}
                       >
-                        [선택]
+                        {terms}
                       </Text>
-                    )}
-                    <Text
-                      className={`ml-[2px] font-n-bd text-b-sm ${
-                        !checked && 'text-b-sm text-gray-400'
-                      }`}
+                    </Pressable>
+                    <Pressable
+                      onPress={() => {
+                        setIsTermsModalVisible(true);
+                        setSelectedTerm(id);
+                      }}
                     >
-                      {terms}
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => {
-                      setIsTermsModalVisible(true);
-                      setSelectedTerm(id);
-                    }}
-                  >
-                    <RightArrowIcon />
-                  </Pressable>
-                </View>
-              );
-            })}
+                      <RightArrowIcon />
+                    </Pressable>
+                  </View>
+                );
+              })}
+            </View>
           </View>
+
           <LongButton
-            label='동의하고 계속하기'
+            label='동의하고 로그인'
             onPress={onPressSubmit}
             disabled={!isEssentialChecked}
           />

--- a/app/oauth.tsx
+++ b/app/oauth.tsx
@@ -1,267 +1,87 @@
 // app/oauth.tsx
 
-import CircleCheckGrayIcon from '@/assets/icons/auth/ic_circle_check_gray.svg';
-import CircleCheckGreenIcon from '@/assets/icons/auth/ic_circle_check_green.svg';
-import RightArrowIcon from '@/assets/icons/ic_arrow_right.svg';
-import { LongButton } from '@/components/common/buttons/LongButton';
-import Navigation from '@/components/layout/Navigation';
-import { HomeFooterModal } from '@/components/page/home/HomeFooterModal';
-import { useKakaoLogin } from '@/hooks/auth/kakao/useKakaoLogin';
-import { patchTermsAgreed } from '@/services/auth/terms';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { useEffect, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import Svg, { Path } from 'react-native-svg';
+import { Stack, useRouter } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
+import { Text, View } from 'react-native';
+
+import { useKakaoLogin } from '@/hooks/auth/kakao/useKakaoLogin';
 import { postSocialPrelogin } from '../services/auth/prelogin';
 import { usePendingKakaoAuth } from '../store/usePendingKakaoAuth';
 
-const TERMS: { id: string; terms: string; essential: boolean }[] = [
-  { id: 'service', terms: '이용 약관 동의', essential: true },
-  { id: 'privacy', terms: '개인정보 수집/이용 동의', essential: true },
-  { id: 'age', terms: '연령 제한 및 법적 규정 동의', essential: true },
-  { id: 'appUsage', terms: '앱 이용 정보 수집 동의', essential: true },
-  { id: 'notification', terms: '알림 및 푸시 알림 동의', essential: false },
-];
-const ESSENTIAL_IDXS = TERMS.map((t, i) => (t.essential ? i : -1)).filter(
-  (i) => i !== -1,
-);
 export default function OAuth() {
-  const { mode } = useLocalSearchParams<{ mode?: string }>();
-  const isGateMode = mode === 'terms';
   const router = useRouter();
-  const [checkedSet, setCheckedSet] = useState<Set<number>>(new Set());
-  const [isTermsModalVisible, setIsTermsModalVisible] = useState(false);
-  const [selectedTerm, setSelectedTerm] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
-  const [isNewUser, setIsNewUser] = useState(false);
 
-  const { kakaoAccessToken, kakaoRefreshToken, kakaoEmail, clear } =
-    usePendingKakaoAuth();
+  const { kakaoAccessToken, kakaoEmail, clear } = usePendingKakaoAuth();
   const { mutate: finalizeLogin } = useKakaoLogin();
 
-  useEffect(() => {
-    if (isGateMode) {
-      setIsLoading(false);
-      return;
-    }
-    // 기존 kakaoAccessToken 기반 로직
-  }, [isGateMode, kakaoAccessToken, kakaoEmail]);
-
-  const goFinalizeLogin = () => {
-    finalizeLogin(undefined, {
-      onSuccess: async () => {
-        try {
-          // ✅ 신규 유저만 동의 저장
-          if (isNewUser) await patchTermsAgreed({ is_terms_agreed: true });
-        } catch (e) {
-          // 로그아웃
-          // 회원 탈퇴
-          router.replace('/auth/login');
-          console.log('terms patch error:', e);
-        }
-
-        clear();
-        await AsyncStorage.multiRemove([
-          'kakao_flow',
-          'kakao_prelogin_done',
-          'kakao_is_new_user',
-        ]);
-        router.replace('/home');
-      },
-      onError: (err: unknown) => {
-        console.log('finalizeLogin error:', err);
-        router.replace('/auth/login');
-      },
-    });
-  };
+  const didRunRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (didRunRef.current) return;
+    didRunRef.current = true;
 
     (async () => {
-      if (!kakaoAccessToken) return;
-
       try {
-        const res = await postSocialPrelogin({
+        // ✅ 카카오 토큰이 없는데 oauth에 들어오면 잘못된 진입
+        if (!kakaoAccessToken) {
+          router.replace('/auth/login');
+          return;
+        }
+
+        // ✅ 신규/기존 여부 확인(서버 로깅/사전 처리 목적)
+        await postSocialPrelogin({
           provider: 'kakao',
           email: kakaoEmail,
         });
 
-        if (cancelled) return;
+        // ✅ 카카오 로그인/회원가입 최종 처리
+        finalizeLogin(undefined, {
+          onSuccess: async () => {
+            try {
+              clear();
+              await AsyncStorage.multiRemove([
+                'kakao_flow',
+                'kakao_prelogin_done',
+                'kakao_is_new_user',
+              ]);
 
-        if (res.is_new_user) {
-          setIsNewUser(true);
-          setIsLoading(false);
-          return;
-        }
-
-        goFinalizeLogin(); // ✅ 기존 유저면 자동 로그인
+              // ✅ 완료되면 home
+              router.replace('/home');
+            } catch (e) {
+              console.log('kakao cleanup error:', e);
+              router.replace('/auth/login');
+            }
+          },
+          onError: (err: unknown) => {
+            console.log('finalizeLogin error:', err);
+            router.replace('/auth/login');
+          },
+        });
       } catch (e) {
-        console.log('oauth effect error:', e);
-        // 실패 시에는 로그인 화면으로 보내는 게 UX 좋음
+        console.log('oauth error:', e);
         router.replace('/auth/login');
+      } finally {
+        setIsLoading(false);
       }
     })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [kakaoAccessToken, kakaoRefreshToken, kakaoEmail]);
+  }, [kakaoAccessToken, kakaoEmail, finalizeLogin, clear, router]);
 
   if (isLoading) {
     return (
       <View className='items-center justify-center flex-1'>
+        <Stack.Screen options={{ headerShown: false }} />
         <Text></Text>
       </View>
     );
   }
 
-  // 전체 선택 여부 / 필수 항목 모두 선택 여부
-  const isAllChecked = checkedSet.size === TERMS.length;
-
-  const isEssentialChecked = ESSENTIAL_IDXS.every((i) => checkedSet.has(i));
-
-  // 전체 토글
-  const toggleAll = () => {
-    setCheckedSet((prev) =>
-      prev.size === TERMS.length ? new Set() : new Set(TERMS.map((_, i) => i)),
-    );
-  };
-
-  // 개별 토글
-  const toggleItem = (idx: number) => {
-    setCheckedSet((prev) => {
-      const next = new Set(prev);
-      if (next.has(idx)) next.delete(idx);
-      else next.add(idx);
-      return next;
-    });
-  };
-
-  const onPressSubmit = async () => {
-    await AsyncStorage.removeItem('pendingAgreement');
-    // ✅ 이미 로그인된 상태에서 약관만 저장하는 케이스
-    if (isGateMode) {
-      try {
-        await patchTermsAgreed({ is_terms_agreed: true });
-        router.replace('/home');
-      } catch (e) {
-        console.log('terms patch error:', e);
-        router.replace('/auth/login');
-      }
-      return;
-    }
-
-    // ✅ 소셜 로그인 플로우(신규 유저)
-    goFinalizeLogin();
-  };
-
+  // 렌더 UI 없음(라우팅 전용)
   return (
-    <SafeAreaView className='flex-1 bg-white'>
+    <View className='items-center justify-center flex-1'>
       <Stack.Screen options={{ headerShown: false }} />
-      <Navigation title='서비스 이용 약관' />
-      <View className='flex-1'>
-        <View className='flex-col justify-between flex-1 px-5'>
-          <View>
-            <Pressable
-              onPress={toggleAll}
-              className='flex-row items-center mb-[28px] '
-              hitSlop={8}
-            >
-              {isAllChecked ? (
-                <CircleCheckGreenIcon className='mr-[11px]' />
-              ) : (
-                <CircleCheckGrayIcon className='mr-[11px]' />
-              )}
-
-              <Text className='items-center text-gray-700 text-b-lg font-n-eb'>
-                서비스 이용 약관 동의(전체)
-              </Text>
-            </Pressable>
-            <View className='gap-y-[25px] mb-[25px]'>
-              {TERMS.map(({ id, terms, essential }, idx) => {
-                const checked = checkedSet.has(idx);
-                return (
-                  <View
-                    key={idx}
-                    className='flex-row items-center justify-between'
-                  >
-                    <Pressable
-                      onPress={() => toggleItem(idx)}
-                      className='flex-row items-center '
-                      hitSlop={8}
-                    >
-                      <Svg
-                        width={18}
-                        height={18}
-                        viewBox='0 0 18 18'
-                        fill='none'
-                        className='mr-[13px]'
-                      >
-                        <Path
-                          d='M16.5 4.5L6.5 15L1.5 9'
-                          stroke={checked ? '#50D88F' : '#C9CDD2'}
-                          strokeWidth={1.5}
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                        />
-                      </Svg>
-                      {essential ? (
-                        <Text
-                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                        >
-                          [필수]
-                        </Text>
-                      ) : (
-                        <Text
-                          className={`text-b-sm font-n-bd text-gray-400 ${checked ? 'text-gray-700' : 'text-gray-400'}`}
-                        >
-                          [선택]
-                        </Text>
-                      )}
-                      <Text
-                        className={`ml-[2px] font-n-bd text-b-sm ${
-                          !checked && 'text-b-sm text-gray-400'
-                        }`}
-                      >
-                        {terms}
-                      </Text>
-                    </Pressable>
-                    <Pressable
-                      onPress={() => {
-                        setIsTermsModalVisible(true);
-                        setSelectedTerm(id);
-                      }}
-                    >
-                      <RightArrowIcon />
-                    </Pressable>
-                  </View>
-                );
-              })}
-            </View>
-          </View>
-
-          <LongButton
-            label='동의하고 로그인'
-            onPress={onPressSubmit}
-            disabled={!isEssentialChecked}
-          />
-        </View>
-        <HomeFooterModal
-          type={
-            selectedTerm as
-              | 'service'
-              | 'privacy'
-              | 'age'
-              | 'appUsage'
-              | 'notification'
-          }
-          visible={isTermsModalVisible}
-          onClose={() => setIsTermsModalVisible(false)}
-        />
-      </View>
-    </SafeAreaView>
+      <Text></Text>
+    </View>
   );
 }

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -2,10 +2,14 @@
 
 import CircleCheckGrayIcon from '@/assets/icons/auth/ic_circle_check_gray.svg';
 import CircleCheckGreenIcon from '@/assets/icons/auth/ic_circle_check_green.svg';
+import ArrowLeftIcon from '@/assets/icons/ic_arrow_left.svg';
 import RightArrowIcon from '@/assets/icons/ic_arrow_right.svg';
 import { LongButton } from '@/components/common/buttons/LongButton';
 import Navigation from '@/components/layout/Navigation';
 import { HomeFooterModal } from '@/components/page/home/HomeFooterModal';
+import { useLogout } from '@/hooks/useLogout';
+import { useUser } from '@/hooks/useUser';
+import { clearTokens } from '@/lib/authToken';
 import { patchTermsAgreed } from '@/services/auth/terms';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useQueryClient } from '@tanstack/react-query';
@@ -26,7 +30,8 @@ const TERMS: { id: string; terms: string; essential: boolean }[] = [
 export default function Terms() {
   const router = useRouter();
   const { mode } = useLocalSearchParams<{ mode?: string }>(); // mode='terms' 로 들어올 수 있음
-
+  const logout = useLogout();
+  const { deleteUser } = useUser();
   const [checkedSet, setCheckedSet] = useState<Set<number>>(new Set());
   const [isTermsModalVisible, setIsTermsModalVisible] = useState(false);
   const [selectedTerm, setSelectedTerm] = useState<string>('');
@@ -81,10 +86,27 @@ export default function Terms() {
     }
   };
 
+  const handleExit = async () => {
+    try {
+      // 회원탈퇴 API 호출
+      await deleteUser();
+      await clearTokens(); // DELETE /auth/user 등
+
+      router.replace('/auth/login');
+    } catch (e) {
+      console.log('회원탈퇴 실패:', e);
+    }
+  };
   return (
     <SafeAreaView className='flex-1 bg-white'>
       <Stack.Screen options={{ headerShown: false }} />
-      <Navigation title='서비스 이용 약관' />
+      <Navigation
+        title='서비스 이용 약관'
+        left={<ArrowLeftIcon width={20} height={20} />}
+        onLeftPress={() => {
+          handleExit();
+        }}
+      />
       <View className='flex-1'>
         <View className='flex-col justify-between flex-1 px-5'>
           <View>

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -1,0 +1,190 @@
+// app/terms.tsx
+
+import CircleCheckGrayIcon from '@/assets/icons/auth/ic_circle_check_gray.svg';
+import CircleCheckGreenIcon from '@/assets/icons/auth/ic_circle_check_green.svg';
+import RightArrowIcon from '@/assets/icons/ic_arrow_right.svg';
+import { LongButton } from '@/components/common/buttons/LongButton';
+import Navigation from '@/components/layout/Navigation';
+import { HomeFooterModal } from '@/components/page/home/HomeFooterModal';
+import { patchTermsAgreed } from '@/services/auth/terms';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useQueryClient } from '@tanstack/react-query';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useMemo, useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Svg, { Path } from 'react-native-svg';
+
+const TERMS: { id: string; terms: string; essential: boolean }[] = [
+  { id: 'service', terms: '이용 약관 동의', essential: true },
+  { id: 'privacy', terms: '개인정보 수집/이용 동의', essential: true },
+  { id: 'age', terms: '연령 제한 및 법적 규정 동의', essential: true },
+  { id: 'appUsage', terms: '앱 이용 정보 수집 동의', essential: true },
+  { id: 'notification', terms: '알림 및 푸시 알림 동의', essential: false },
+];
+
+export default function Terms() {
+  const router = useRouter();
+  const { mode } = useLocalSearchParams<{ mode?: string }>(); // mode='terms' 로 들어올 수 있음
+
+  const [checkedSet, setCheckedSet] = useState<Set<number>>(new Set());
+  const [isTermsModalVisible, setIsTermsModalVisible] = useState(false);
+  const [selectedTerm, setSelectedTerm] = useState<string>('');
+  const qc = useQueryClient();
+
+  const essentialIdxs = useMemo(
+    () => TERMS.map((t, i) => (t.essential ? i : -1)).filter((i) => i !== -1),
+    [],
+  );
+
+  const isAllChecked = checkedSet.size === TERMS.length;
+  const isEssentialChecked = essentialIdxs.every((i) => checkedSet.has(i));
+
+  const toggleAll = () => {
+    setCheckedSet((prev) =>
+      prev.size === TERMS.length ? new Set() : new Set(TERMS.map((_, i) => i)),
+    );
+  };
+
+  const toggleItem = (idx: number) => {
+    setCheckedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  };
+
+  const onPressSubmit = async () => {
+    try {
+      await AsyncStorage.removeItem('pendingAgreement'); // 기존 키 쓰고 있으면 유지
+
+      await patchTermsAgreed({ is_terms_agreed: true });
+      qc.setQueryData(['mainScreen'], (old: any) => {
+        if (!old) return old;
+        return {
+          ...old,
+          user: {
+            ...old.user,
+            isTermsAgreed: true,
+          },
+        };
+      });
+
+      qc.invalidateQueries({ queryKey: ['mainScreen'] });
+
+      // ✅ 약관 동의 후 홈(index)로
+      router.replace('/home');
+    } catch (e) {
+      console.log('terms patch error:', e);
+      router.replace('/auth/login');
+    }
+  };
+
+  return (
+    <SafeAreaView className='flex-1 bg-white'>
+      <Stack.Screen options={{ headerShown: false }} />
+      <Navigation title='서비스 이용 약관' />
+      <View className='flex-1'>
+        <View className='flex-col justify-between flex-1 px-5'>
+          <View>
+            <Pressable
+              onPress={toggleAll}
+              className='flex-row items-center mb-[28px]'
+              hitSlop={8}
+            >
+              {isAllChecked ? (
+                <CircleCheckGreenIcon className='mr-[11px]' />
+              ) : (
+                <CircleCheckGrayIcon className='mr-[11px]' />
+              )}
+
+              <Text className='items-center text-gray-700 text-b-lg font-n-eb'>
+                서비스 이용 약관 동의(전체)
+              </Text>
+            </Pressable>
+
+            <View className='gap-y-[25px] mb-[25px]'>
+              {TERMS.map(({ id, terms, essential }, idx) => {
+                const checked = checkedSet.has(idx);
+
+                return (
+                  <View
+                    key={idx}
+                    className='flex-row items-center justify-between'
+                  >
+                    <Pressable
+                      onPress={() => toggleItem(idx)}
+                      className='flex-row items-center'
+                      hitSlop={8}
+                    >
+                      <Svg
+                        width={18}
+                        height={18}
+                        viewBox='0 0 18 18'
+                        fill='none'
+                        className='mr-[13px]'
+                      >
+                        <Path
+                          d='M16.5 4.5L6.5 15L1.5 9'
+                          stroke={checked ? '#50D88F' : '#C9CDD2'}
+                          strokeWidth={1.5}
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                        />
+                      </Svg>
+
+                      <Text
+                        className={`text-b-sm font-n-bd ${
+                          checked ? 'text-gray-700' : 'text-gray-400'
+                        }`}
+                      >
+                        {essential ? '[필수]' : '[선택]'}
+                      </Text>
+
+                      <Text
+                        className={`ml-[2px] font-n-bd text-b-sm ${
+                          checked ? 'text-gray-700' : 'text-gray-400'
+                        }`}
+                      >
+                        {terms}
+                      </Text>
+                    </Pressable>
+
+                    <Pressable
+                      onPress={() => {
+                        setIsTermsModalVisible(true);
+                        setSelectedTerm(id);
+                      }}
+                    >
+                      <RightArrowIcon />
+                    </Pressable>
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+
+          <LongButton
+            label={mode === 'terms' ? '동의하고 계속하기' : '동의하기'}
+            onPress={onPressSubmit}
+            disabled={!isEssentialChecked}
+          />
+        </View>
+
+        <HomeFooterModal
+          type={
+            selectedTerm as
+              | 'service'
+              | 'privacy'
+              | 'age'
+              | 'appUsage'
+              | 'notification'
+          }
+          visible={isTermsModalVisible}
+          onClose={() => setIsTermsModalVisible(false)}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -271,6 +271,8 @@ PODS:
     - ExpoModulesCore
   - ExpoSystemUI (6.0.9):
     - ExpoModulesCore
+  - ExpoTrackingTransparency (6.0.8):
+    - ExpoModulesCore
   - ExpoWebBrowser (15.0.10):
     - ExpoModulesCore
   - EXUpdatesInterface (2.0.0):
@@ -2051,7 +2053,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNCKakaoCore (2.4.2):
+  - RNCKakaoCore (2.4.4):
     - hermes-engine
     - KakaoSDKCommon (= 2.22.0)
     - RCTRequired
@@ -2074,7 +2076,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNCKakaoUser (2.4.2):
+  - RNCKakaoUser (2.4.4):
     - hermes-engine
     - KakaoSDKUser (= 2.22.0)
     - RCTRequired
@@ -2425,6 +2427,7 @@ DEPENDENCIES:
   - ExpoSplashScreen (from `../node_modules/expo-splash-screen/ios`)
   - ExpoSymbols (from `../node_modules/expo-symbols/ios`)
   - ExpoSystemUI (from `../node_modules/expo-system-ui/ios`)
+  - ExpoTrackingTransparency (from `../node_modules/expo-tracking-transparency/ios`)
   - ExpoWebBrowser (from `../node_modules/expo-web-browser/ios`)
   - EXUpdatesInterface (from `../node_modules/expo-updates-interface/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -2582,6 +2585,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-symbols/ios"
   ExpoSystemUI:
     :path: "../node_modules/expo-system-ui/ios"
+  ExpoTrackingTransparency:
+    :path: "../node_modules/expo-tracking-transparency/ios"
   ExpoWebBrowser:
     :path: "../node_modules/expo-web-browser/ios"
   EXUpdatesInterface:
@@ -2777,6 +2782,7 @@ SPEC CHECKSUMS:
   ExpoSplashScreen: 76af87337650d06926aa7d0157fe98b4fddca336
   ExpoSymbols: 349ee2b4d7d5ff3ea8436467914f8a67635aa354
   ExpoSystemUI: 2ad325f361a2fcd96a464e8574e19935c461c9cc
+  ExpoTrackingTransparency: 4f823a38ff7c0efea4cac722ecbc0589278ff548
   ExpoWebBrowser: 17b064c621789e41d4816c95c93f429b84971f52
   EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
   FBLazyVector: 9e0cd874afd81d9a4d36679daca991b58b260d42
@@ -2855,8 +2861,8 @@ SPEC CHECKSUMS:
   ReactNativeDependencies: ed6d1e64802b150399f04f1d5728ec16b437251e
   RNAppleAuthentication: 9027af8aa92b4719ef1b6030a8e954d37079473a
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
-  RNCKakaoCore: 6be0b351d7685d9c9245c5d70bc4edb562696a53
-  RNCKakaoUser: c179239f489a98130f2e5bb95ee30fc5ac21177f
+  RNCKakaoCore: 0a1a8ec116481c877c89f45adc6db0bbb690604a
+  RNCKakaoUser: bdd3297532203e256a3e386960b099c9185e4cc3
   RNGestureHandler: 2914750df066d89bf9d8f48a10ad5f0051108ac3
   RNReanimated: e5c702a3e24cc1c68b2de67671713f35461678f4
   RNScreens: d8d6f1792f6e7ac12b0190d33d8d390efc0c1845

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "expo-status-bar": "~3.0.8",
         "expo-symbols": "~1.0.7",
         "expo-system-ui": "~6.0.7",
+        "expo-tracking-transparency": "^6.0.8",
         "expo-web-browser": "~15.0.7",
         "fast-text-encoding": "^1.0.6",
         "leo-profanity": "^1.8.0",
@@ -8031,6 +8032,16 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-tracking-transparency": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/expo-tracking-transparency/-/expo-tracking-transparency-6.0.8.tgz",
+      "integrity": "sha512-4/NW47Kmrtj3J0udUmzxiq01gRY+vG8wFsUop6CTOVWlk+2MypjDFwBSscHcyiS2dJGNQLOQSBZ1RNhLdgSBOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-updates-interface": {

--- a/services/auth/terms.ts
+++ b/services/auth/terms.ts
@@ -1,0 +1,11 @@
+// services/auth/terms.ts
+import { axiosInstance } from '../index';
+
+export type TermsAgreed = {
+  is_terms_agreed: boolean;
+};
+
+export async function patchTermsAgreed(req: TermsAgreed): Promise<TermsAgreed> {
+  const { data } = await axiosInstance.patch<TermsAgreed>('/auth/terms/', req);
+  return data;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->
#148


## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->
- 소셜로그인 이용약관 동의 플로우를 변경하였습니다.
    - 메인 화면에서 이용약관 미 동의 시 이용약관 화면으로 강제 이동.
- 소셜로그인 디자인을 반영하였습ㄴ디ㅏ
    - 네비게이트 헤더 추가, 뒤로가기 추가 (로그인 화면)
- 애플로그인에도 이용약관 동의 플로우를 적용하였습니다.

## 🗣️ 팀원에게 공유할 내용
- 소셜로그인 이용약관 관련 부분은 안드로이드 배포 후 테스트가 필요할 것 같습니다.
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->