### PR TITLE
fix: 배너 상세 이미지 id 오름차순 정렬로 순서 일관성 보장

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "다시",
     "slug": "dasii",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "orientation": "portrait",
     "icon": "./assets/images/img_logo.png",
     "scheme": "dasii",

--- a/app/home/banner.tsx
+++ b/app/home/banner.tsx
@@ -13,6 +13,7 @@ export default function Banner() {
   const { data: bannersRaw = [] } = useFetchBannersQuery();
   const detailImages = bannersRaw
     .filter((item) => String(item.order) === id)
+    .sort((a, b) => a.id - b.id)
     .map((item) => ({ uri: item.detail_image_url }));
 
   const handleShare = async () => {


### PR DESCRIPTION
## 🔗 관련 이슈

- #207

## 📌 PR 내용

- order 추가하여 배너 이미지가 순서대로 나오도록 일관성 보장