### PR TITLE
feat: 배너 상세 이미지 detail_images 배열 응답 구조 대응

### DIFF
--- a/app/home/banner.tsx
+++ b/app/home/banner.tsx
@@ -11,10 +11,8 @@ export default function Banner() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
   const { data: bannersRaw = [] } = useFetchBannersQuery();
-  const detailImages = bannersRaw
-    .filter((item) => String(item.order) === id)
-    .sort((a, b) => a.id - b.id)
-    .map((item) => ({ uri: item.detail_image_url }));
+  const banner = bannersRaw.find((item) => String(item.order) === id);
+  const detailImages = (banner?.detail_images ?? []).map((url) => ({ uri: url }));
 
   const handleShare = async () => {
     try {

--- a/types/models/main.ts
+++ b/types/models/main.ts
@@ -15,6 +15,7 @@ export interface IBannerAPIItem {
   id: number;
   image_url: string;
   detail_image_url: string;
+  detail_images: string[];
   order: number;
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- #209

## 📌 PR 내용

- `IBannerAPIItem에 detail_images: string[]` 추가 (기존 `detail_image_url` 유지로 구버전 호환)
- `banner.tsx`에서 `filter/sort` 로직 → `find` + `detail_images` 배열 직접 사용으로 단순화